### PR TITLE
Fix cross origin problem loading json

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "https://ground-context.github.io/ground/api/swagger.json";
+        url = "http://www.ground-context.org/ground/api/swagger.json";
       }
 
 


### PR DESCRIPTION
#16
- This will make it so that the api documentation is available at http://www.ground-context.org/ground/api
- To update the static documentation:
  - Start ground server
  - copy localhost:8080/swagger.json
  - replace the [swagger spec file](https://github.com/ground-context/ground/blob/master/docs/api/swagger.json) with what you just copied
  - done
