### PR TITLE
README: Update CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-[![Build Status](https://travis-ci.org/ground-context/ground.png)](https://travis-ci.org/ground-context/ground)
-[![Coveralls](https://img.shields.io/coveralls/ground-context/ground.svg)](https://coveralls.io/github/ground-context/ground)
-
-
 # Ground
+
+[![Build Status](https://travis-ci.org/ground-context/ground.svg?branch=master)](https://travis-ci.org/ground-context/ground)
+[![Coverage Status](https://coveralls.io/repos/github/ground-context/ground/badge.svg?branch=master)](https://coveralls.io/github/ground-context/ground?branch=master)
 
 Ground is an open-source data context service under development in UC Berkeley's [RISE Lab](http://rise.cs.berkeley.edu). Ground serves as a central model, API, and repistory for capturing the broad context in which data is used. Our goal is to address practical problems for the Big Data community in the short term and to open up opportunities for long-term research and innovation.
 
@@ -25,10 +24,8 @@ To start a Ground server: `java -jar ground-core/target/ground-core-0.1-SNAPSHOT
 
 ## License
 
-Ground is licensed under the [Apache v2
-License](http://www.apache.org/licenses/LICENSE-2.0). 
+Ground is licensed under the [Apache v2 License](http://www.apache.org/licenses/LICENSE-2.0).
 
 ## Contributing
 
-Please see the guidelines in
-[CONTRIBUTING.md](https://github.com/ground-context/ground/blob/master/CONTRIBUTING.md).
+Please see the guidelines in [CONTRIBUTING.md](https://github.com/ground-context/ground/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
The Travis badge is now an SVG, so it should no longer look low-resolution.