### PR TITLE
[GROUND-28] Cassandra Test Cleanup

### DIFF
--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeFactory.java
@@ -83,10 +83,14 @@ public class CassandraEdgeFactory extends EdgeFactory {
       try {
         resultSet = connection.equalitySelect("edge", DBClient.SELECT_STAR, predicates);
       } catch (EmptyResultException eer) {
+        connection.abort();
+
         throw new GroundException("No Edge found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
+        connection.abort();
+
         throw new GroundException("No Edge found with name " + name + ".");
       }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeVersionFactory.java
@@ -102,10 +102,14 @@ public class CassandraEdgeVersionFactory extends EdgeVersionFactory {
       try {
         resultSet = connection.equalitySelect("edge_version", DBClient.SELECT_STAR, predicates);
       } catch (EmptyResultException eer) {
+        connection.abort();
+
         throw new GroundException("No EdgeVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
+        connection.abort();
+
         throw new GroundException("No EdgeVersion found with id " + id + ".");
       }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactory.java
@@ -83,10 +83,14 @@ public class CassandraGraphFactory extends GraphFactory {
       try {
         resultSet = connection.equalitySelect("graph", DBClient.SELECT_STAR, predicates);
       } catch (EmptyResultException eer) {
+        connection.abort();
+
         throw new GroundException("No Graph found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
+        connection.abort();
+
         throw new GroundException("No Graph found with name " + name + ".");
       }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeFactory.java
@@ -83,10 +83,14 @@ public class CassandraLineageEdgeFactory extends LineageEdgeFactory {
       try {
         resultSet = connection.equalitySelect("lineage_edge", DBClient.SELECT_STAR, predicates);
       } catch (EmptyResultException eer) {
+        connection.abort();
+
         throw new GroundException("No LineageEdge found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
+        connection.abort();
+
         throw new GroundException("No LineageEdge found with name " + name + ".");
       }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeVersionFactory.java
@@ -105,10 +105,14 @@ public class CassandraLineageEdgeVersionFactory extends LineageEdgeVersionFactor
       try {
         resultSet = connection.equalitySelect("lineage_edge_version", DBClient.SELECT_STAR, predicates);
       } catch (EmptyResultException eer) {
+        connection.abort();
+
         throw new GroundException("No LineageEdgeVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
+        connection.abort();
+
         throw new GroundException("No LineageEdgeVersion found with id " + id + ".");
       }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
@@ -209,11 +209,11 @@ public class CassandraClient implements DBClient {
     }
 
     public void commit() throws GroundDBException {
-      // do nothing; Cassandra doesn't have txns
+      this.session.close();
     }
 
     public void abort() throws GroundDBException {
-      // do nothing; Cassandra doesn't have txns
+      this.session.close();
     }
   }
 
@@ -249,5 +249,9 @@ public class CassandraClient implements DBClient {
         }
         break;
     }
+  }
+
+  public void closeCluster() {
+    this.cluster.close();
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/CassandraTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/CassandraTest.java
@@ -1,6 +1,8 @@
 package edu.berkeley.ground.api;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,34 +22,40 @@ import edu.berkeley.ground.util.IdGenerator;
 public class CassandraTest {
   private static String TEST_DB_NAME = "test";
 
-  protected CassandraClient cassandraClient;
-  protected CassandraFactories factories;
-  protected CassandraVersionFactory versionFactory;
-  protected CassandraVersionSuccessorFactory versionSuccessorFactory;
-  protected CassandraVersionHistoryDAGFactory versionHistoryDAGFactory;
-  protected CassandraItemFactory itemFactory;
-  protected CassandraRichVersionFactory richVersionFactory;
-  protected CassandraTagFactory tagFactory;
+  protected static CassandraClient cassandraClient;
+  protected static CassandraFactories factories;
+  protected static CassandraVersionFactory versionFactory;
+  protected static CassandraVersionSuccessorFactory versionSuccessorFactory;
+  protected static CassandraVersionHistoryDAGFactory versionHistoryDAGFactory;
+  protected static CassandraItemFactory itemFactory;
+  protected static CassandraRichVersionFactory richVersionFactory;
+  protected static CassandraTagFactory tagFactory;
 
-  public CassandraTest() throws GroundDBException {
-    this.cassandraClient = new CassandraClient("localhost", 9160, "test", "test", "");
-    this.factories = new CassandraFactories(cassandraClient, 0, 1);
+  @BeforeClass
+  public static void setup() throws GroundDBException {
+    cassandraClient = new CassandraClient("localhost", 9160, "test", "test", "");
+    factories = new CassandraFactories(cassandraClient, 0, 1);
 
-    this.versionFactory = new CassandraVersionFactory();
-    this.versionSuccessorFactory = new CassandraVersionSuccessorFactory(new IdGenerator(0, 1, false));
-    this.versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(versionSuccessorFactory);
-    this.itemFactory = new CassandraItemFactory(versionHistoryDAGFactory);
-    this.tagFactory = new CassandraTagFactory();
+    versionFactory = new CassandraVersionFactory();
+    versionSuccessorFactory = new CassandraVersionSuccessorFactory(new IdGenerator(0, 1, false));
+    versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(versionSuccessorFactory);
+    itemFactory = new CassandraItemFactory(versionHistoryDAGFactory);
+    tagFactory = new CassandraTagFactory();
 
-    this.richVersionFactory = new CassandraRichVersionFactory(versionFactory,
+    richVersionFactory = new CassandraRichVersionFactory(versionFactory,
         (CassandraStructureVersionFactory) factories.getStructureVersionFactory(), tagFactory);
   }
 
   @Before
-  public void setup() throws IOException, InterruptedException {
+  public void setupTest() throws IOException, InterruptedException {
     Process p = Runtime.getRuntime().exec("cqlsh -k " + TEST_DB_NAME + " -f truncate.cql", null, new File("scripts/cassandra/"));
     p.waitFor();
 
     p.destroy();
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException, InterruptedException {
+    cassandraClient.closeCluster();
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactoryTest.java
@@ -18,12 +18,12 @@ public class CassandraGraphFactoryTest extends CassandraTest {
   public void testGraphCreation() {
     try {
       String testName = "test";
-      CassandraGraphFactory edgeFactory = (CassandraGraphFactory) super.factories.getGraphFactory();
-      edgeFactory.create(testName);
+      CassandraGraphFactory graphFactory = (CassandraGraphFactory) super.factories.getGraphFactory();
+      graphFactory.create(testName);
 
-      Graph edge = edgeFactory.retrieveFromDatabase(testName);
+      Graph graph = graphFactory.retrieveFromDatabase(testName);
 
-      assertEquals(testName, edge.getName());
+      assertEquals(testName, graph.getName());
     } catch (GroundException ge) {
       fail(ge.getMessage());
     }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
@@ -136,6 +136,8 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
 
         structureVersionId = super.factories.getStructureVersionFactory().create(structureId, structureVersionAttributes, new ArrayList<>()).getId();
       } catch (GroundException ge) {
+        connection.abort();
+
         fail(ge.getMessage());
       }
 

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
@@ -23,89 +23,70 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
 
   @Test
   public void testReference() throws GroundException {
-    CassandraConnection connection = super.cassandraClient.getConnection();
-    long id = 1;
-    String testReference = "http://www.google.com";
-    Map<String, String> parameters = new HashMap<>();
-    parameters.put("http", "GET");
+    CassandraConnection connection = null;
 
-    super.richVersionFactory.insertIntoDatabase(connection, id, new HashMap<>(), -1, testReference, parameters);
+    try {
+      connection = super.cassandraClient.getConnection();
+      long id = 1;
+      String testReference = "http://www.google.com";
+      Map<String, String> parameters = new HashMap<>();
+      parameters.put("http", "GET");
 
-    RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      super.richVersionFactory.insertIntoDatabase(connection, id, new HashMap<>(), -1, testReference, parameters);
 
-    assertEquals(id, retrieved.getId());
-    assertEquals(testReference, retrieved.getReference());
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
 
-    Map<String, String> retrievedParams = retrieved.getParameters();
-    for (String key : parameters.keySet()) {
-      assert (retrievedParams).containsKey(key);
-      assertEquals(parameters.get(key), retrievedParams.get(key));
+      assertEquals(id, retrieved.getId());
+      assertEquals(testReference, retrieved.getReference());
+
+      Map<String, String> retrievedParams = retrieved.getParameters();
+      for (String key : parameters.keySet()) {
+        assert (retrievedParams).containsKey(key);
+        assertEquals(parameters.get(key), retrievedParams.get(key));
+      }
+    } finally {
+      connection.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    CassandraConnection connection = super.cassandraClient.getConnection();
-    long id = 1;
+    CassandraConnection connection = null;
 
-    Map<String, Tag> tags = new HashMap<>();
-    tags.put("justkey", new Tag(-1, "justkey", null, null));
-    tags.put("withintvalue", new Tag(-1, "withintvalue", 1, GroundType.INTEGER));
-    tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
-    tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
+    try {
+      connection = super.cassandraClient.getConnection();
+      long id = 1;
 
-    super.richVersionFactory.insertIntoDatabase(connection, id, tags, -1, null, new HashMap<>());
+      Map<String, Tag> tags = new HashMap<>();
+      tags.put("justkey", new Tag(-1, "justkey", null, null));
+      tags.put("withintvalue", new Tag(-1, "withintvalue", 1, GroundType.INTEGER));
+      tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
+      tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
-    RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      super.richVersionFactory.insertIntoDatabase(connection, id, tags, -1, null, new HashMap<>());
 
-    assertEquals(id, retrieved.getId());
-    assertEquals(tags.size(), retrieved.getTags().size());
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
 
-    Map<String, Tag> retrievedTags = retrieved.getTags();
-    for (String key : tags.keySet()) {
-      assert (retrievedTags).containsKey(key);
-      assertEquals(tags.get(key), retrievedTags.get(key));
-      assertEquals(retrieved.getId(), retrievedTags.get(key).getVersionId());
+      assertEquals(id, retrieved.getId());
+      assertEquals(tags.size(), retrieved.getTags().size());
+
+      Map<String, Tag> retrievedTags = retrieved.getTags();
+      for (String key : tags.keySet()) {
+        assert (retrievedTags).containsKey(key);
+        assertEquals(tags.get(key), retrievedTags.get(key));
+        assertEquals(retrieved.getId(), retrievedTags.get(key).getVersionId());
+      }
+    } finally {
+      connection.abort();
     }
   }
 
   @Test
   public void testStructureVersionConformation() throws GroundException {
-    CassandraConnection connection = super.cassandraClient.getConnection();
-    long id = 1;
-
-    String structureName = "testStructure";
-    long structureId = super.factories.getStructureFactory().create(structureName).getId();
-
-    Map<String, GroundType> structureVersionAttributes = new HashMap<>();
-    structureVersionAttributes.put("intfield", GroundType.INTEGER);
-    structureVersionAttributes.put("boolfield", GroundType.BOOLEAN);
-    structureVersionAttributes.put("strfield", GroundType.STRING);
-
-    long structureVersionId = super.factories.getStructureVersionFactory().create(
-        structureId, structureVersionAttributes, new ArrayList<>()).getId();
-
-    Map<String, Tag> tags = new HashMap<>();
-    tags.put("intfield", new Tag(-1, "intfield", 1, GroundType.INTEGER));
-    tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
-    tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
-
-    super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
-        new HashMap<>());
-
-    RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
-    assertEquals(retrieved.getStructureVersionId(), structureVersionId);
-  }
-
-  @Test(expected = GroundException.class)
-  public void testStructureVersionFails() throws GroundException {
-    long structureVersionId = -1;
     CassandraConnection connection = null;
-    long id = 1;
-
-    // none of these operations should fail
     try {
       connection = super.cassandraClient.getConnection();
+      long id = 1;
 
       String structureName = "testStructure";
       long structureId = super.factories.getStructureFactory().create(structureName).getId();
@@ -115,18 +96,59 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
       structureVersionAttributes.put("boolfield", GroundType.BOOLEAN);
       structureVersionAttributes.put("strfield", GroundType.STRING);
 
-      structureVersionId = super.factories.getStructureVersionFactory().create( structureId, structureVersionAttributes, new ArrayList<>()).getId();
-    } catch (GroundException ge) {
-      fail(ge.getMessage());
+      long structureVersionId = super.factories.getStructureVersionFactory().create(
+          structureId, structureVersionAttributes, new ArrayList<>()).getId();
+
+      Map<String, Tag> tags = new HashMap<>();
+      tags.put("intfield", new Tag(-1, "intfield", 1, GroundType.INTEGER));
+      tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
+      tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
+
+      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+          new HashMap<>());
+
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      assertEquals(retrieved.getStructureVersionId(), structureVersionId);
+    } finally {
+      connection.abort();
     }
+  }
 
-    Map<String, Tag> tags = new HashMap<>();
-    tags.put("intfield", new Tag(-1, "intfield", 1, GroundType.INTEGER));
-    tags.put("intfield", new Tag(-1, "strfield", "1", GroundType.STRING));
-    tags.put("intfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
+  @Test(expected = GroundException.class)
+  public void testStructureVersionFails() throws GroundException {
+    CassandraConnection connection = null;
 
-    // this should fail
-    super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
-        new HashMap<>());
+    try {
+      long structureVersionId = -1;
+      long id = 1;
+
+      // none of these operations should fail
+      try {
+        connection = super.cassandraClient.getConnection();
+
+        String structureName = "testStructure";
+        long structureId = super.factories.getStructureFactory().create(structureName).getId();
+
+        Map<String, GroundType> structureVersionAttributes = new HashMap<>();
+        structureVersionAttributes.put("intfield", GroundType.INTEGER);
+        structureVersionAttributes.put("boolfield", GroundType.BOOLEAN);
+        structureVersionAttributes.put("strfield", GroundType.STRING);
+
+        structureVersionId = super.factories.getStructureVersionFactory().create(structureId, structureVersionAttributes, new ArrayList<>()).getId();
+      } catch (GroundException ge) {
+        fail(ge.getMessage());
+      }
+
+      Map<String, Tag> tags = new HashMap<>();
+      tags.put("intfield", new Tag(-1, "intfield", 1, GroundType.INTEGER));
+      tags.put("intfield", new Tag(-1, "strfield", "1", GroundType.STRING));
+      tags.put("intfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
+
+      // this should fail
+      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+          new HashMap<>());
+    } finally {
+      connection.abort();
+    }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
@@ -23,184 +23,215 @@ public class CassandraItemFactoryTest extends CassandraTest {
 
   @Test
   public void testCorrectUpdateWithParent() throws GroundException {
-    long testId = 1;
-    CassandraConnection connection = super.cassandraClient.getConnection();
-
-    super.itemFactory.insertIntoDatabase(connection, testId);
-
-    long fromId = 123;
-    long toId = 456;
-
-    super.versionFactory.insertIntoDatabase(connection, fromId);
-    super.versionFactory.insertIntoDatabase(connection, toId);
-
-    List<Long> parentIds = new ArrayList<>();
-    parentIds.add(0L);
-    super.itemFactory.update(connection, testId, fromId, new ArrayList<>());
-
-    parentIds.clear();
-    parentIds.add(fromId);
-    super.itemFactory.update(connection, testId, toId, parentIds);
-
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
-
-    assertEquals(2, dag.getEdgeIds().size());
-    assertEquals(toId, (long) dag.getLeaves().get(0));
-
-    VersionSuccessor<?> successor = null;
-    for (long id : dag.getEdgeIds()) {
-      successor = super.versionSuccessorFactory.retrieveFromDatabase(connection, id);
-
-      if (!(successor.getFromId() == 0)) {
-        break;
-      }
-    }
-
-    if (successor != null) {
-      assertEquals(fromId, successor.getFromId());
-      assertEquals(toId, successor.getToId());
-
-      return;
-    }
-
-    fail();
-  }
-
-  @Test
-  public void testCorrectUpdateWithoutParent() throws GroundException {
-    long testId = 1;
-    CassandraConnection connection = super.cassandraClient.getConnection();
-
-    super.itemFactory.insertIntoDatabase(connection, testId);
-    long toId = 123;
-    super.versionFactory.insertIntoDatabase(connection, toId);
-
-    List<Long> parentIds = new ArrayList<>();
-
-    // No parent is specified, and there is no other version in this Item, we should
-    // automatically make this a child of EMPTY
-    super.itemFactory.update(connection, testId, toId, parentIds);
-
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
-
-    assertEquals(1, dag.getEdgeIds().size());
-    assertEquals(toId, (long) dag.getLeaves().get(0));
-
-    VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
-        connection, dag.getEdgeIds().get(0));
-
-    assertEquals(0, successor.getFromId());
-    assertEquals(toId, successor.getToId());
-  }
-
-  @Test
-  public void testCorrectUpdateWithLinearHistory() throws GroundException {
-    long testId = 1;
-    CassandraConnection connection = super.cassandraClient.getConnection();
-
-    super.itemFactory.insertIntoDatabase(connection, testId);
-
-    long fromId = 123;
-    long toId = 456;
-
-    super.versionFactory.insertIntoDatabase(connection, fromId);
-    super.versionFactory.insertIntoDatabase(connection, toId);
-    List<Long> parentIds = new ArrayList<>();
-
-    // first, make from a child of EMPTY
-    super.itemFactory.update(connection, testId, fromId, parentIds);
-
-
-    // then, add to as a child and make sure that it becomes a child of from
-    parentIds = new ArrayList<>();
-    parentIds.add(fromId);
-    super.itemFactory.update(connection, testId, toId, parentIds);
-
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
-
-    assertEquals(2, dag.getEdgeIds().size());
-    assertEquals(toId, (long) dag.getLeaves().get(0));
-
-    VersionSuccessor<?> toSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-        connection, dag.getEdgeIds().get(0));
-
-    VersionSuccessor<?> fromSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-        connection, dag.getEdgeIds().get(1));
-
-    if (!(fromSuccessor.getFromId() == 0)) {
-      VersionSuccessor<?> tmp = fromSuccessor;
-      fromSuccessor = toSuccessor;
-      toSuccessor = tmp;
-    }
-
-    assertEquals(0, fromSuccessor.getFromId());
-    assertEquals(fromId, fromSuccessor.getToId());
-
-    assertEquals(fromId, toSuccessor.getFromId());
-    assertEquals(toId, toSuccessor.getToId());
-  }
-
-  @Test(expected = GroundException.class)
-  public void testIncorrectUpdate() throws GroundException {
-    long testId = 1;
-    long fromId = 123;
-    long toId = 456;
     CassandraConnection connection = null;
 
     try {
       connection = super.cassandraClient.getConnection();
 
+      long testId = 1;
+
       super.itemFactory.insertIntoDatabase(connection, testId);
 
+      long fromId = 123;
+      long toId = 456;
+
+      super.versionFactory.insertIntoDatabase(connection, fromId);
       super.versionFactory.insertIntoDatabase(connection, toId);
 
-    } catch (GroundException ge) {
-      fail(ge.getMessage());
+      List<Long> parentIds = new ArrayList<>();
+      parentIds.add(0L);
+      super.itemFactory.update(connection, testId, fromId, new ArrayList<>());
+
+      parentIds.clear();
+      parentIds.add(fromId);
+      super.itemFactory.update(connection, testId, toId, parentIds);
+
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
+
+      assertEquals(2, dag.getEdgeIds().size());
+      assertEquals(toId, (long) dag.getLeaves().get(0));
+
+      VersionSuccessor<?> successor = null;
+      for (long id : dag.getEdgeIds()) {
+        successor = super.versionSuccessorFactory.retrieveFromDatabase(connection, id);
+
+        if (!(successor.getFromId() == 0)) {
+          break;
+        }
+      }
+
+      if (successor != null) {
+        assertEquals(fromId, successor.getFromId());
+        assertEquals(toId, successor.getToId());
+
+        return;
+      }
+
+      fail();
+    } finally {
+      connection.abort();
     }
+  }
 
-    List<Long> parentIds = new ArrayList<>();
-    parentIds.add(fromId);
+  @Test
+  public void testCorrectUpdateWithoutParent() throws GroundException {
+    CassandraConnection connection = null;
 
-    // this should fail because fromId is not a valid version
-    super.itemFactory.update(connection, testId, toId, parentIds);
+    try {
+      connection = super.cassandraClient.getConnection();
+
+      long testId = 1;
+
+      super.itemFactory.insertIntoDatabase(connection, testId);
+      long toId = 123;
+      super.versionFactory.insertIntoDatabase(connection, toId);
+
+      List<Long> parentIds = new ArrayList<>();
+
+      // No parent is specified, and there is no other version in this Item, we should
+      // automatically make this a child of EMPTY
+      super.itemFactory.update(connection, testId, toId, parentIds);
+
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
+
+      assertEquals(1, dag.getEdgeIds().size());
+      assertEquals(toId, (long) dag.getLeaves().get(0));
+
+      VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
+          connection, dag.getEdgeIds().get(0));
+
+      assertEquals(0, successor.getFromId());
+      assertEquals(toId, successor.getToId());
+    } finally {
+      connection.abort();
+    }
+  }
+
+  @Test
+  public void testCorrectUpdateWithLinearHistory() throws GroundException {
+    CassandraConnection connection = null;
+
+    try {
+      long testId = 1;
+      connection = super.cassandraClient.getConnection();
+
+      super.itemFactory.insertIntoDatabase(connection, testId);
+
+      long fromId = 123;
+      long toId = 456;
+
+      super.versionFactory.insertIntoDatabase(connection, fromId);
+      super.versionFactory.insertIntoDatabase(connection, toId);
+      List<Long> parentIds = new ArrayList<>();
+
+      // first, make from a child of EMPTY
+      super.itemFactory.update(connection, testId, fromId, parentIds);
+
+
+      // then, add to as a child and make sure that it becomes a child of from
+      parentIds = new ArrayList<>();
+      parentIds.add(fromId);
+      super.itemFactory.update(connection, testId, toId, parentIds);
+
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
+
+      assertEquals(2, dag.getEdgeIds().size());
+      assertEquals(toId, (long) dag.getLeaves().get(0));
+
+      VersionSuccessor<?> toSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
+          connection, dag.getEdgeIds().get(0));
+
+      VersionSuccessor<?> fromSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
+          connection, dag.getEdgeIds().get(1));
+
+      if (!(fromSuccessor.getFromId() == 0)) {
+        VersionSuccessor<?> tmp = fromSuccessor;
+        fromSuccessor = toSuccessor;
+        toSuccessor = tmp;
+      }
+
+      assertEquals(0, fromSuccessor.getFromId());
+      assertEquals(fromId, fromSuccessor.getToId());
+
+      assertEquals(fromId, toSuccessor.getFromId());
+      assertEquals(toId, toSuccessor.getToId());
+    } finally {
+      connection.abort();
+    }
+  }
+
+  @Test(expected = GroundException.class)
+  public void testIncorrectUpdate() throws GroundException {
+    CassandraConnection connection = null;
+
+    try {
+      long testId = 1;
+    long fromId = 123;
+    long toId = 456;
+
+      try {
+        connection = super.cassandraClient.getConnection();
+
+        super.itemFactory.insertIntoDatabase(connection, testId);
+
+        super.versionFactory.insertIntoDatabase(connection, toId);
+
+      } catch (GroundException ge) {
+        fail(ge.getMessage());
+      }
+
+      List<Long> parentIds = new ArrayList<>();
+      parentIds.add(fromId);
+
+      // this should fail because fromId is not a valid version
+      super.itemFactory.update(connection, testId, toId, parentIds);
+    } finally {
+      connection.abort();
+    }
   }
 
   @Test
   public void testMultipleParents() throws GroundException {
-    long testId = 1;
-    CassandraConnection connection = super.cassandraClient.getConnection();
+    CassandraConnection connection = null;
 
-    super.itemFactory.insertIntoDatabase(connection, testId);
+    try {
+      connection = super.cassandraClient.getConnection();
+      long testId = 1;
 
-    long parentOne = 123;
-    long parentTwo = 456;
-    long child = 789;
+      super.itemFactory.insertIntoDatabase(connection, testId);
 
-    super.versionFactory.insertIntoDatabase(connection, parentOne);
-    super.versionFactory.insertIntoDatabase(connection, parentTwo);
-    super.versionFactory.insertIntoDatabase(connection, child);
-    List<Long> parentIds = new ArrayList<>();
+      long parentOne = 123;
+      long parentTwo = 456;
+      long child = 789;
 
-    // first, make the parents children of EMPTY
-    super.itemFactory.update(connection, testId, parentOne, parentIds);
-    super.itemFactory.update(connection, testId, parentTwo, parentIds);
+      super.versionFactory.insertIntoDatabase(connection, parentOne);
+      super.versionFactory.insertIntoDatabase(connection, parentTwo);
+      super.versionFactory.insertIntoDatabase(connection, child);
+      List<Long> parentIds = new ArrayList<>();
 
-    // then, add to as a child and make sure that it becomes a child of from
-    parentIds = new ArrayList<>();
-    parentIds.add(parentOne);
-    parentIds.add(parentTwo);
-    super.itemFactory.update(connection, testId, child, parentIds);
+      // first, make the parents children of EMPTY
+      super.itemFactory.update(connection, testId, parentOne, parentIds);
+      super.itemFactory.update(connection, testId, parentTwo, parentIds);
 
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
+      // then, add to as a child and make sure that it becomes a child of from
+      parentIds = new ArrayList<>();
+      parentIds.add(parentOne);
+      parentIds.add(parentTwo);
+      super.itemFactory.update(connection, testId, child, parentIds);
 
-    assertEquals(4, dag.getEdgeIds().size());
-    assertEquals(1, dag.getLeaves().size());
-    assertEquals(child, (long) dag.getLeaves().get(0));
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
 
-    // No need to check the version successors because we have tests for those.
+      assertEquals(4, dag.getEdgeIds().size());
+      assertEquals(1, dag.getLeaves().size());
+      assertEquals(child, (long) dag.getLeaves().get(0));
+
+      // No need to check the version successors because we have tests for those.
+    } finally {
+      connection.abort();
+    }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
@@ -180,6 +180,8 @@ public class CassandraItemFactoryTest extends CassandraTest {
         super.versionFactory.insertIntoDatabase(connection, toId);
 
       } catch (GroundException ge) {
+        connection.abort();
+
         fail(ge.getMessage());
       }
 

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionHistoryDAGFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionHistoryDAGFactoryTest.java
@@ -20,45 +20,54 @@ public class CassandraVersionHistoryDAGFactoryTest extends CassandraTest {
 
   @Test
   public void testVersionHistoryDAGCreation() throws GroundException {
-    long testId = 1;
-    super.versionHistoryDAGFactory.create(testId);
-    CassandraConnection connection = super.cassandraClient.getConnection();
+    CassandraConnection connection = null;
+    try {
+      connection = super.cassandraClient.getConnection();
+      long testId = 1;
+      super.versionHistoryDAGFactory.create(testId);
 
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
 
-    assertEquals(0, dag.getEdgeIds().size());
-
-    connection.abort();
+      assertEquals(0, dag.getEdgeIds().size());
+    } finally {
+      connection.abort();
+    }
   }
 
   @Test
   public void testAddEdge() throws GroundException {
-    long testId = 1;
-    CassandraConnection connection = super.cassandraClient.getConnection();
-    super.versionHistoryDAGFactory.create(testId);
+    CassandraConnection connection = null;
 
-    VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
+    try {
+      connection = super.cassandraClient.getConnection();
+      long testId = 1;
+      super.versionHistoryDAGFactory.create(testId);
 
-    long fromId = 123;
-    long toId = 456;
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
 
-    super.versionFactory.insertIntoDatabase(connection, fromId);
-    super.versionFactory.insertIntoDatabase(connection, toId);
+      long fromId = 123;
+      long toId = 456;
 
-    super.versionHistoryDAGFactory.addEdge(connection, dag, fromId, toId, testId);
+      super.versionFactory.insertIntoDatabase(connection, fromId);
+      super.versionFactory.insertIntoDatabase(connection, toId);
 
-    VersionHistoryDAG<?> retrieved = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-        testId);
+      super.versionHistoryDAGFactory.addEdge(connection, dag, fromId, toId, testId);
 
-    assertEquals(1, retrieved.getEdgeIds().size());
-    assertEquals(toId, (long) retrieved.getLeaves().get(0));
+      VersionHistoryDAG<?> retrieved = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
+          testId);
 
-    VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
-        connection, retrieved.getEdgeIds().get(0));
+      assertEquals(1, retrieved.getEdgeIds().size());
+      assertEquals(toId, (long) retrieved.getLeaves().get(0));
 
-    assertEquals(fromId, successor.getFromId());
-    assertEquals(toId, successor.getToId());
+      VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
+          connection, retrieved.getEdgeIds().get(0));
+
+      assertEquals(fromId, successor.getFromId());
+      assertEquals(toId, successor.getToId());
+    } finally {
+      connection.abort();
+    }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactoryTest.java
@@ -54,6 +54,8 @@ public class CassandraVersionSuccessorFactoryTest extends CassandraTest {
         connection = super.cassandraClient.getConnection();
         super.versionFactory.insertIntoDatabase(connection, fromId);
       } catch (GroundException ge) {
+        connection.abort();
+
         fail(ge.getMessage());
       }
 


### PR DESCRIPTION
* Make sure to close connections after each Cassandra test. Makes tests faster.
* Close each cluster connection after each test class because each class creates a new cluster connection. This makes tests a little slower but will probably pay off as we have more and more expensive tests.