### PR TITLE
[GROUND-26] db: Cache prepared statements

### DIFF
--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeFactory.java
@@ -14,17 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class EdgeFactory {
-  public abstract Edge create(String name, Map<String, Tag> tags) throws GroundDBException;
+  public abstract Edge create(String name, Map<String, Tag> tags) throws GroundException;
 
-  public abstract Edge retrieveFromDatabase(String name) throws GroundDBException;
+  public abstract Edge retrieveFromDatabase(String name) throws GroundException;
 
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
   protected static Edge construct(long id, String name, Map<String, Tag> tags) {
     return new Edge(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeFactory.java
@@ -14,18 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class EdgeFactory {
-  public abstract Edge create(String name, Map<String, Tag> tags) throws GroundException;
+  public abstract Edge create(String name, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract Edge retrieveFromDatabase(String name) throws GroundException;
+  public abstract Edge retrieveFromDatabase(String name) throws GroundDBException;
 
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
   protected static Edge construct(long id, String name, Map<String, Tag> tags) {
     return new Edge(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
@@ -27,10 +27,10 @@ public abstract class EdgeVersionFactory {
                                      long edgeId,
                                      long fromId,
                                      long toId,
-                                     List<Long> parentIds) throws GroundDBException;
+                                     List<Long> parentIds) throws GroundException;
 
 
-  public abstract EdgeVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract EdgeVersion retrieveFromDatabase(long id) throws GroundException;
 
   protected static EdgeVersion construct(long id,
                                          Map<String, Tag> tags,
@@ -39,7 +39,7 @@ public abstract class EdgeVersionFactory {
                                          Map<String, String> referenceParameters,
                                          long edgeId,
                                          long fromId,
-                                         long toId) throws GroundDBException {
+                                         long toId) throws GroundException {
 
     return new EdgeVersion(id, tags, structureVersionId, reference, referenceParameters, edgeId, fromId, toId);
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/EdgeVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
@@ -27,10 +27,10 @@ public abstract class EdgeVersionFactory {
                                      long edgeId,
                                      long fromId,
                                      long toId,
-                                     List<Long> parentIds) throws GroundException;
+                                     List<Long> parentIds) throws GroundDBException;
 
 
-  public abstract EdgeVersion retrieveFromDatabase(long id) throws GroundException;
+  public abstract EdgeVersion retrieveFromDatabase(long id) throws GroundDBException;
 
   protected static EdgeVersion construct(long id,
                                          Map<String, Tag> tags,
@@ -39,7 +39,7 @@ public abstract class EdgeVersionFactory {
                                          Map<String, String> referenceParameters,
                                          long edgeId,
                                          long fromId,
-                                         long toId) throws GroundException {
+                                         long toId) throws GroundDBException {
 
     return new EdgeVersion(id, tags, structureVersionId, reference, referenceParameters, edgeId, fromId, toId);
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphFactory.java
@@ -14,17 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class GraphFactory {
-  public abstract Graph create(String name, Map<String, Tag> tags) throws GroundDBException;
+  public abstract Graph create(String name, Map<String, Tag> tags) throws GroundException;
 
-  public abstract Graph retrieveFromDatabase(String name) throws GroundDBException;
+  public abstract Graph retrieveFromDatabase(String name) throws GroundException;
 
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
   protected static Graph construct(long id, String name, Map<String, Tag> tags) {
     return new Graph(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphFactory.java
@@ -14,18 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class GraphFactory {
-  public abstract Graph create(String name, Map<String, Tag> tags) throws GroundException;
+  public abstract Graph create(String name, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract Graph retrieveFromDatabase(String name) throws GroundException;
+  public abstract Graph retrieveFromDatabase(String name) throws GroundDBException;
 
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
   protected static Graph construct(long id, String name, Map<String, Tag> tags) {
     return new Graph(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
@@ -26,9 +26,9 @@ public abstract class GraphVersionFactory {
                                       Map<String, String> referenceParameters,
                                       long graphId,
                                       List<Long> edgeVersionIds,
-                                      List<Long> parentIds) throws GroundDBException;
+                                      List<Long> parentIds) throws GroundException;
 
-  public abstract GraphVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract GraphVersion retrieveFromDatabase(long id) throws GroundException;
 
   protected static GraphVersion construct(long id,
                                           Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/GraphVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
@@ -26,9 +26,9 @@ public abstract class GraphVersionFactory {
                                       Map<String, String> referenceParameters,
                                       long graphId,
                                       List<Long> edgeVersionIds,
-                                      List<Long> parentIds) throws GroundException;
+                                      List<Long> parentIds) throws GroundDBException;
 
-  public abstract GraphVersion retrieveFromDatabase(long id) throws GroundException;
+  public abstract GraphVersion retrieveFromDatabase(long id) throws GroundDBException;
 
   protected static GraphVersion construct(long id,
                                           Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeFactory.java
@@ -14,20 +14,19 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class NodeFactory {
-  public abstract Node create(String name, Map<String, Tag> tags) throws GroundException;
+  public abstract Node create(String name, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract Node retrieveFromDatabase(String name) throws GroundException;
+  public abstract Node retrieveFromDatabase(String name) throws GroundDBException;
 
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
-  public abstract List<Long> getLeaves(String name) throws GroundException;
+  public abstract List<Long> getLeaves(String name) throws GroundDBException;
 
   protected static Node construct(long id, String name, Map<String, Tag> tags) {
     return new Node(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeFactory.java
@@ -14,19 +14,19 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class NodeFactory {
-  public abstract Node create(String name, Map<String, Tag> tags) throws GroundDBException;
+  public abstract Node create(String name, Map<String, Tag> tags) throws GroundException;
 
-  public abstract Node retrieveFromDatabase(String name) throws GroundDBException;
+  public abstract Node retrieveFromDatabase(String name) throws GroundException;
 
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
-  public abstract List<Long> getLeaves(String name) throws GroundDBException;
+  public abstract List<Long> getLeaves(String name) throws GroundException;
 
   protected static Node construct(long id, String name, Map<String, Tag> tags) {
     return new Node(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
@@ -25,13 +25,13 @@ public abstract class NodeVersionFactory {
                                      String reference,
                                      Map<String, String> referenceParameters,
                                      long nodeId,
-                                     List<Long> parentIds) throws GroundException;
+                                     List<Long> parentIds) throws GroundDBException;
 
-  public abstract NodeVersion retrieveFromDatabase(long id) throws GroundException;
+  public abstract NodeVersion retrieveFromDatabase(long id) throws GroundDBException;
 
-  public abstract List<Long> getTransitiveClosure(long nodeVersionId) throws GroundException;
+  public abstract List<Long> getTransitiveClosure(long nodeVersionId) throws GroundDBException;
 
-  public abstract List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameLike) throws GroundException;
+  public abstract List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameLike) throws GroundDBException;
 
   public static NodeVersion construct(long id,
                                       Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/NodeVersionFactory.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
@@ -25,13 +25,13 @@ public abstract class NodeVersionFactory {
                                      String reference,
                                      Map<String, String> referenceParameters,
                                      long nodeId,
-                                     List<Long> parentIds) throws GroundDBException;
+                                     List<Long> parentIds) throws GroundException;
 
-  public abstract NodeVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract NodeVersion retrieveFromDatabase(long id) throws GroundException;
 
-  public abstract List<Long> getTransitiveClosure(long nodeVersionId) throws GroundDBException;
+  public abstract List<Long> getTransitiveClosure(long nodeVersionId) throws GroundException;
 
-  public abstract List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameLike) throws GroundDBException;
+  public abstract List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameLike) throws GroundException;
 
   public static NodeVersion construct(long id,
                                       Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/RichVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/RichVersionFactory.java
@@ -16,6 +16,7 @@ package edu.berkeley.ground.api.models;
 
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.Map;
 
@@ -24,9 +25,9 @@ public abstract class RichVersionFactory {
                                           Map<String, Tag> tags,
                                           long structureVersionId,
                                           String reference,
-                                          Map<String, String> referenceParameters) throws GroundDBException;
+                                          Map<String, String> referenceParameters) throws GroundException;
 
-  public abstract RichVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract RichVersion retrieveFromDatabase(long id) throws GroundException;
 
   protected static RichVersion construct(long id,
                                          Map<String, Tag> tags,
@@ -42,7 +43,7 @@ public abstract class RichVersionFactory {
    * @param structureVersion the StructureVersion to check against
    * @param tags             the provided tags
    */
-  protected static void checkStructureTags(StructureVersion structureVersion, Map<String, Tag> tags) throws GroundDBException {
+  protected static void checkStructureTags(StructureVersion structureVersion, Map<String, Tag> tags) throws GroundException {
     Map<String, GroundType> structureVersionAttributes = structureVersion.getAttributes();
 
     if (tags.isEmpty()) {

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/RichVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/RichVersionFactory.java
@@ -15,20 +15,18 @@
 package edu.berkeley.ground.api.models;
 
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.Map;
 
 public abstract class RichVersionFactory {
-  public abstract void insertIntoDatabase(GroundDBConnection connection,
-                                          long id,
+  public abstract void insertIntoDatabase(long id,
                                           Map<String, Tag> tags,
                                           long structureVersionId,
                                           String reference,
-                                          Map<String, String> referenceParameters) throws GroundException;
+                                          Map<String, String> referenceParameters) throws GroundDBException;
 
-  public abstract RichVersion retrieveFromDatabase(GroundDBConnection connection, long id) throws GroundException;
+  public abstract RichVersion retrieveFromDatabase(long id) throws GroundDBException;
 
   protected static RichVersion construct(long id,
                                          Map<String, Tag> tags,
@@ -44,21 +42,21 @@ public abstract class RichVersionFactory {
    * @param structureVersion the StructureVersion to check against
    * @param tags             the provided tags
    */
-  protected static void checkStructureTags(StructureVersion structureVersion, Map<String, Tag> tags) throws GroundException {
+  protected static void checkStructureTags(StructureVersion structureVersion, Map<String, Tag> tags) throws GroundDBException {
     Map<String, GroundType> structureVersionAttributes = structureVersion.getAttributes();
 
     if (tags.isEmpty()) {
-      throw new GroundException("No tags were specified");
+      throw new GroundDBException("No tags were specified");
     }
 
     for (String key : structureVersionAttributes.keySet()) {
       // check if such a tag exists
       if (!tags.keySet().contains(key)) {
-        throw new GroundException("No tag with key " + key + " was specified.");
+        throw new GroundDBException("No tag with key " + key + " was specified.");
       } else if (tags.get(key).getValueType() == null) { // check that value type is specified
-        throw new GroundException("Tag with key " + key + " did not have a value.");
+        throw new GroundDBException("Tag with key " + key + " did not have a value.");
       } else if (!tags.get(key).getValueType().equals(structureVersionAttributes.get(key))) { // check that the value type is the same
-        throw new GroundException("Tag with key " + key + " did not have a value of the correct type.");
+        throw new GroundDBException("Tag with key " + key + " did not have a value of the correct type.");
       }
     }
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureFactory.java
@@ -14,20 +14,19 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class StructureFactory {
-  public abstract Structure create(String name, Map<String, Tag> tags) throws GroundException;
+  public abstract Structure create(String name, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract Structure retrieveFromDatabase(String name) throws GroundException;
+  public abstract Structure retrieveFromDatabase(String name) throws GroundDBException;
 
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
-  public abstract List<Long> getLeaves(String name) throws GroundException;
+  public abstract List<Long> getLeaves(String name) throws GroundDBException;
 
   protected static Structure construct(long id, String name, Map<String, Tag> tags) {
     return new Structure(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureFactory.java
@@ -14,19 +14,19 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class StructureFactory {
-  public abstract Structure create(String name, Map<String, Tag> tags) throws GroundDBException;
+  public abstract Structure create(String name, Map<String, Tag> tags) throws GroundException;
 
-  public abstract Structure retrieveFromDatabase(String name) throws GroundDBException;
+  public abstract Structure retrieveFromDatabase(String name) throws GroundException;
 
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
-  public abstract List<Long> getLeaves(String name) throws GroundDBException;
+  public abstract List<Long> getLeaves(String name) throws GroundException;
 
   protected static Structure construct(long id, String name, Map<String, Tag> tags) {
     return new Structure(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureVersionFactory.java
@@ -15,7 +15,7 @@
 package edu.berkeley.ground.api.models;
 
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
@@ -23,9 +23,9 @@ import java.util.Map;
 public abstract class StructureVersionFactory {
   public abstract StructureVersion create(long structureId,
                                           Map<String, GroundType> attributes,
-                                          List<Long> parentIds) throws GroundException;
+                                          List<Long> parentIds) throws GroundDBException;
 
-  public abstract StructureVersion retrieveFromDatabase(long id) throws GroundException;
+  public abstract StructureVersion retrieveFromDatabase(long id) throws GroundDBException;
 
   protected static StructureVersion construct(long id, long structureId, Map<String, GroundType> attributes) {
     return new StructureVersion(id, structureId, attributes);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/StructureVersionFactory.java
@@ -15,7 +15,7 @@
 package edu.berkeley.ground.api.models;
 
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
@@ -23,9 +23,9 @@ import java.util.Map;
 public abstract class StructureVersionFactory {
   public abstract StructureVersion create(long structureId,
                                           Map<String, GroundType> attributes,
-                                          List<Long> parentIds) throws GroundDBException;
+                                          List<Long> parentIds) throws GroundException;
 
-  public abstract StructureVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract StructureVersion retrieveFromDatabase(long id) throws GroundException;
 
   protected static StructureVersion construct(long id, long structureId, Map<String, GroundType> attributes) {
     return new StructureVersion(id, structureId, attributes);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/TagFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/TagFactory.java
@@ -14,18 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class TagFactory {
-  public abstract Map<String, Tag> retrieveFromDatabaseByVersionId(GroundDBConnection connection, long id) throws GroundException;
+  public abstract Map<String, Tag> retrieveFromDatabaseByVersionId(long id) throws GroundDBException;
 
-  public abstract Map<String, Tag> retrieveFromDatabaseByItemId(GroundDBConnection connection, long id) throws GroundException;
+  public abstract Map<String, Tag> retrieveFromDatabaseByItemId(long id) throws GroundDBException;
 
-  public abstract List<Long> getVersionIdsByTag(GroundDBConnection connection, String tag) throws GroundException;
+  public abstract List<Long> getVersionIdsByTag(String tag) throws GroundDBException;
 
-  public abstract List<Long> getItemIdsByTag(GroundDBConnection connection, String tag) throws GroundException;
+  public abstract List<Long> getItemIdsByTag(String tag) throws GroundDBException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/TagFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/TagFactory.java
@@ -14,17 +14,17 @@
 
 package edu.berkeley.ground.api.models;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class TagFactory {
-  public abstract Map<String, Tag> retrieveFromDatabaseByVersionId(long id) throws GroundDBException;
+  public abstract Map<String, Tag> retrieveFromDatabaseByVersionId(long id) throws GroundException;
 
-  public abstract Map<String, Tag> retrieveFromDatabaseByItemId(long id) throws GroundDBException;
+  public abstract Map<String, Tag> retrieveFromDatabaseByItemId(long id) throws GroundException;
 
-  public abstract List<Long> getVersionIdsByTag(String tag) throws GroundDBException;
+  public abstract List<Long> getVersionIdsByTag(String tag) throws GroundException;
 
-  public abstract List<Long> getItemIdsByTag(String tag) throws GroundDBException;
+  public abstract List<Long> getItemIdsByTag(String tag) throws GroundException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraItemFactory;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class CassandraEdgeFactory extends EdgeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraEdgeFactory.class);
-  private CassandraClient dbClient;
-  private CassandraItemFactory itemFactory;
+  private final CassandraClient dbClient;
+  private final CassandraItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraEdgeFactory(CassandraItemFactory itemFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,33 +47,29 @@ public class CassandraEdgeFactory extends EdgeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Edge create(String name, Map<String, Tag> tags) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Edge create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("edge", insertions);
+      this.dbClient.insert("edge", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created edge " + name + ".");
       return EdgeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public Edge retrieveFromDatabase(String name) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Edge retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
 
@@ -83,34 +77,34 @@ public class CassandraEdgeFactory extends EdgeFactory {
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("edge", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("edge", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No Edge found with name " + name + ".");
+        throw new GroundDBException("No Edge found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No Edge found with name " + name + ".");
+        throw new GroundDBException("No Edge found with name " + name + ".");
       }
 
       long id = resultSet.getLong(0);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved edge " + name + ".");
 
       return EdgeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraEdgeVersionFactory.java
@@ -20,12 +20,11 @@ import edu.berkeley.ground.api.models.RichVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,11 +37,11 @@ import java.util.stream.Collectors;
 
 public class CassandraEdgeVersionFactory extends EdgeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraEdgeVersionFactory.class);
-  private CassandraClient dbClient;
+  private final CassandraClient dbClient;
 
-  private CassandraEdgeFactory edgeFactory;
-  private CassandraRichVersionFactory richVersionFactory;
-  private IdGenerator idGenerator;
+  private final CassandraEdgeFactory edgeFactory;
+  private final CassandraRichVersionFactory richVersionFactory;
+  private final IdGenerator idGenerator;
 
   public CassandraEdgeVersionFactory(CassandraEdgeFactory edgeFactory, CassandraRichVersionFactory richVersionFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -58,16 +57,14 @@ public class CassandraEdgeVersionFactory extends EdgeVersionFactory {
                             long edgeId,
                             long fromId,
                             long toId,
-                            List<Long> parentIds) throws GroundException {
-
-    CassandraConnection connection = this.dbClient.getConnection();
+                            List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
 
       tags = tags.values().stream().collect(Collectors.toMap(Tag::getKey, tag -> new Tag(id, tag.getKey(), tag.getValue(), tag.getValueType())));
 
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
@@ -75,54 +72,52 @@ public class CassandraEdgeVersionFactory extends EdgeVersionFactory {
       insertions.add(new DbDataContainer("from_node_version_id", GroundType.LONG, fromId));
       insertions.add(new DbDataContainer("to_node_version_id", GroundType.LONG, toId));
 
-      connection.insert("edge_version", insertions);
+      this.dbClient.insert("edge_version", insertions);
 
-      this.edgeFactory.update(connection, edgeId, id, parentIds);
+      this.edgeFactory.update(edgeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created edge version " + id + " in edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
       throw e;
     }
   }
 
-  public EdgeVersion retrieveFromDatabase(long id) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public EdgeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("edge_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("edge_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No EdgeVersion found with id " + id + ".");
+        throw new GroundDBException("No EdgeVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No EdgeVersion found with id " + id + ".");
+        throw new GroundDBException("No EdgeVersion found with id " + id + ".");
       }
 
       long edgeId = resultSet.getLong("edge_id");
       long fromId = resultSet.getLong("from_node_version_id");
       long toId = resultSet.getLong("to_node_version_id");
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved edge version " + id + " in Edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraGraphFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraItemFactory;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class CassandraGraphFactory extends GraphFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraGraphFactory.class);
-  private CassandraClient dbClient;
-  private CassandraItemFactory itemFactory;
+  private final CassandraClient dbClient;
+  private final CassandraItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraGraphFactory(CassandraItemFactory itemFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,68 +47,64 @@ public class CassandraGraphFactory extends GraphFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Graph create(String name, Map<String, Tag> tags) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Graph create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("graph", insertions);
+      this.dbClient.insert("graph", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created graph " + name + ".");
 
       return GraphFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public Graph retrieveFromDatabase(String name) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Graph retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("graph", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("graph", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No Graph found with name " + name + ".");
+        throw new GroundDBException("No Graph found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No Graph found with name " + name + ".");
+        throw new GroundDBException("No Graph found with name " + name + ".");
       }
 
       long id = resultSet.getLong(0);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved graph " + name + ".");
 
       return GraphFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraNodeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraNodeVersionFactory.java
@@ -125,32 +125,19 @@ public class CassandraNodeVersionFactory extends NodeVersionFactory {
     }
   }
 
-  public List<Long> getTransitiveClosure(long nodeVersionId) throws GroundException {
+  public List<Long> getTransitiveClosure(long nodeVersionId) {
     CassandraConnection connection = this.dbClient.getConnection();
-    try {
-      List<Long> result = connection.transitiveClosure(nodeVersionId);
+    List<Long> result = connection.transitiveClosure(nodeVersionId);
 
-      connection.commit();
-      return result;
-    } catch (GroundException e) {
-      connection.abort();
-
-      throw e;
-    }
+    connection.commit();
+    return result;
   }
 
-  public List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameRegex) throws GroundException {
+  public List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameRegex) {
     CassandraConnection connection = this.dbClient.getConnection();
+    List<Long> result = connection.adjacentNodes(nodeVersionId, edgeNameRegex);
 
-    try {
-      List<Long> result = connection.adjacentNodes(nodeVersionId, edgeNameRegex);
-
-      connection.commit();
-      return result;
-    } catch (GroundException e) {
-      connection.abort();
-
-      throw e;
-    }
+    connection.commit();
+    return result;
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraNodeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraNodeVersionFactory.java
@@ -20,12 +20,11 @@ import edu.berkeley.ground.api.models.RichVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,11 +37,11 @@ import java.util.stream.Collectors;
 
 public class CassandraNodeVersionFactory extends NodeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraNodeVersionFactory.class);
-  private CassandraClient dbClient;
-  private CassandraNodeFactory nodeFactory;
-  private CassandraRichVersionFactory richVersionFactory;
+  private final CassandraClient dbClient;
+  private final CassandraNodeFactory nodeFactory;
+  private final CassandraRichVersionFactory richVersionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraNodeVersionFactory(CassandraNodeFactory nodeFactory, CassandraRichVersionFactory richVersionFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -57,9 +56,7 @@ public class CassandraNodeVersionFactory extends NodeVersionFactory {
                             String reference,
                             Map<String, String> referenceParameters,
                             long nodeId,
-                            List<Long> parentIds) throws GroundException {
-
-    CassandraConnection connection = this.dbClient.getConnection();
+                            List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
@@ -67,77 +64,73 @@ public class CassandraNodeVersionFactory extends NodeVersionFactory {
       // add the id of the version to the tag
       tags = tags.values().stream().collect(Collectors.toMap(Tag::getKey, tag -> new Tag(id, tag.getKey(), tag.getValue(), tag.getValueType())));
 
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
       insertions.add(new DbDataContainer("node_id", GroundType.LONG, nodeId));
 
-      connection.insert("node_version", insertions);
+      this.dbClient.insert("node_version", insertions);
 
-      this.nodeFactory.update(connection, nodeId, id, parentIds);
+      this.nodeFactory.update(nodeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created node version " + id + " in node " + nodeId + ".");
 
       return NodeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, nodeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public NodeVersion retrieveFromDatabase(long id) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public NodeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("node_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("node_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No NodeVersion found with id " + id + ".");
+        throw new GroundDBException("No NodeVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No NodeVersion found with id " + id + ".");
+        throw new GroundDBException("No NodeVersion found with id " + id + ".");
       }
 
       long nodeId = resultSet.getLong(1);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved node version " + id + " in node " + nodeId + ".");
 
       return NodeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), nodeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
   public List<Long> getTransitiveClosure(long nodeVersionId) {
-    CassandraConnection connection = this.dbClient.getConnection();
-    List<Long> result = connection.transitiveClosure(nodeVersionId);
+    List<Long> result = this.dbClient.transitiveClosure(nodeVersionId);
 
-    connection.commit();
+    this.dbClient.commit();
     return result;
   }
 
   public List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameRegex) {
-    CassandraConnection connection = this.dbClient.getConnection();
-    List<Long> result = connection.adjacentNodes(nodeVersionId, edgeNameRegex);
+    List<Long> result = this.dbClient.adjacentNodes(nodeVersionId, edgeNameRegex);
 
-    connection.commit();
+    this.dbClient.commit();
     return result;
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactory.java
@@ -20,38 +20,37 @@ import edu.berkeley.ground.api.models.StructureVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraVersionFactory;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.*;
 
 public class CassandraRichVersionFactory extends RichVersionFactory {
-  private CassandraVersionFactory versionFactory;
-  private CassandraStructureVersionFactory structureVersionFactory;
-  private CassandraTagFactory tagFactory;
+  private final CassandraClient dbClient;
+  private final CassandraVersionFactory versionFactory;
+  private final CassandraStructureVersionFactory structureVersionFactory;
+  private final CassandraTagFactory tagFactory;
 
-  public CassandraRichVersionFactory(CassandraVersionFactory versionFactory,
+  public CassandraRichVersionFactory(CassandraClient dbClient,
+                                     CassandraVersionFactory versionFactory,
                                      CassandraStructureVersionFactory structureVersionFactory,
                                      CassandraTagFactory tagFactory) {
-
+    this.dbClient = dbClient;
     this.versionFactory = versionFactory;
     this.structureVersionFactory = structureVersionFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer,
-                                 long id,
+  public void insertIntoDatabase(long id,
                                  Map<String, Tag> tags,
                                  long structureVersionId,
                                  String reference,
-                                 Map<String, String> referenceParameters) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-    this.versionFactory.insertIntoDatabase(connection, id);
+                                 Map<String, String> referenceParameters) throws GroundDBException {
+    this.versionFactory.insertIntoDatabase(id);
 
     if (structureVersionId != -1) {
       StructureVersion structureVersion = this.structureVersionFactory.retrieveFromDatabase(structureVersionId);
@@ -64,7 +63,7 @@ public class CassandraRichVersionFactory extends RichVersionFactory {
     insertions.add(new DbDataContainer("structure_version_id", GroundType.LONG, structureVersionId));
     insertions.add(new DbDataContainer("reference", GroundType.STRING, reference));
 
-    connection.insert("rich_version", insertions);
+    this.dbClient.insert("rich_version", insertions);
 
     for (String key : tags.keySet()) {
       Tag tag = tags.get(key);
@@ -81,7 +80,7 @@ public class CassandraRichVersionFactory extends RichVersionFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.insert("rich_version_tag", tagInsertion);
+      this.dbClient.insert("rich_version_tag", tagInsertion);
     }
 
     for (String key : referenceParameters.keySet()) {
@@ -90,41 +89,39 @@ public class CassandraRichVersionFactory extends RichVersionFactory {
       parameterInsertion.add(new DbDataContainer("key", GroundType.STRING, key));
       parameterInsertion.add(new DbDataContainer("value", GroundType.STRING, referenceParameters.get(key)));
 
-      connection.insert("rich_version_external_parameter", parameterInsertion);
+      this.dbClient.insert("rich_version_external_parameter", parameterInsertion);
     }
   }
 
-  public RichVersion retrieveFromDatabase(GroundDBConnection connectionPointer, long id) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
+  public RichVersion retrieveFromDatabase(long id) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect("rich_version", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No RichVersion found with id " + id + ".");
+      resultSet = this.dbClient.equalitySelect("rich_version", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No RichVersion found with id " + id + ".");
     }
 
     if (!resultSet.next()) {
-      throw new GroundException("No RichVersion found with id " + id + ".");
+      throw new GroundDBException("No RichVersion found with id " + id + ".");
     }
 
     List<DbDataContainer> parameterPredicates = new ArrayList<>();
     parameterPredicates.add(new DbDataContainer("rich_version_id", GroundType.LONG, id));
     Map<String, String> referenceParameters = new HashMap<>();
     try {
-      QueryResults parameterSet = connection.equalitySelect("rich_version_external_parameter", DBClient.SELECT_STAR, parameterPredicates);
+      QueryResults parameterSet = this.dbClient.equalitySelect("rich_version_external_parameter", DBClient.SELECT_STAR, parameterPredicates);
 
       while (parameterSet.next()) {
         referenceParameters.put(parameterSet.getString("key"), parameterSet.getString("value"));
       }
-    } catch (EmptyResultException eer) {
+    } catch (EmptyResultException e) {
       // do nothing; this just means that there are no referenceParameters
     }
 
-    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(connection, id);
+    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(id);
 
     String reference = resultSet.getString("reference");
     long structureVersionId = resultSet.getLong("structure_version_id");

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraStructureFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraStructureFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraItemFactory;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class CassandraStructureFactory extends StructureFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraStructureFactory.class);
-  private CassandraClient dbClient;
-  private CassandraItemFactory itemFactory;
+  private final CassandraClient dbClient;
+  private final CassandraItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraStructureFactory(CassandraItemFactory itemFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,85 +47,79 @@ public class CassandraStructureFactory extends StructureFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Structure create(String name, Map<String, Tag> tags) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Structure create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("structure", insertions);
+      this.dbClient.insert("structure", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created structure " + name + ".");
 
       return StructureFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public List<Long> getLeaves(String name) throws GroundException {
+  public List<Long> getLeaves(String name) throws GroundDBException {
     Structure structure = this.retrieveFromDatabase(name);
 
-    CassandraConnection connection = this.dbClient.getConnection();
-
     try {
-      List<Long> leaves = this.itemFactory.getLeaves(connection, structure.getId());
-      connection.commit();
+      List<Long> leaves = this.itemFactory.getLeaves(structure.getId());
+      this.dbClient.commit();
 
       return leaves;
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public Structure retrieveFromDatabase(String name) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public Structure retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("structure", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("structure", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No Structure found with name " + name + ".");
+        throw new GroundDBException("No Structure found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No Structure found with name " + name + ".");
+        throw new GroundDBException("No Structure found with name " + name + ".");
       }
 
       long id = resultSet.getLong(0);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved structure " + name + ".");
 
       return StructureFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraStructureVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraStructureVersionFactory.java
@@ -19,12 +19,11 @@ import edu.berkeley.ground.api.models.StructureVersionFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraVersionFactory;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -34,11 +33,11 @@ import java.util.*;
 
 public class CassandraStructureVersionFactory extends StructureVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraStructureVersionFactory.class);
-  private CassandraClient dbClient;
-  private CassandraStructureFactory structureFactory;
-  private CassandraVersionFactory versionFactory;
+  private final CassandraClient dbClient;
+  private final CassandraStructureFactory structureFactory;
+  private final CassandraVersionFactory versionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraStructureVersionFactory(CassandraStructureFactory structureFactory, CassandraVersionFactory versionFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,20 +48,18 @@ public class CassandraStructureVersionFactory extends StructureVersionFactory {
 
   public StructureVersion create(long structureId,
                                  Map<String, GroundType> attributes,
-                                 List<Long> parentIds) throws GroundException {
-
-    CassandraConnection connection = this.dbClient.getConnection();
+                                 List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
 
-      this.versionFactory.insertIntoDatabase(connection, id);
+      this.versionFactory.insertIntoDatabase(id);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
       insertions.add(new DbDataContainer("structure_id", GroundType.LONG, structureId));
 
-      connection.insert("structure_version", insertions);
+      this.dbClient.insert("structure_version", insertions);
 
       for (String key : attributes.keySet()) {
         List<DbDataContainer> itemInsertions = new ArrayList<>();
@@ -70,25 +67,23 @@ public class CassandraStructureVersionFactory extends StructureVersionFactory {
         itemInsertions.add(new DbDataContainer("key", GroundType.STRING, key));
         itemInsertions.add(new DbDataContainer("type", GroundType.STRING, attributes.get(key).toString()));
 
-        connection.insert("structure_version_attribute", itemInsertions);
+        this.dbClient.insert("structure_version_attribute", itemInsertions);
       }
 
-      this.structureFactory.update(connection, structureId, id, parentIds);
+      this.structureFactory.update(structureId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created structure version " + id + " in structure " + structureId + ".");
 
       return StructureVersionFactory.construct(id, structureId, attributes);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public StructureVersion retrieveFromDatabase(long id) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public StructureVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
 
       List<DbDataContainer> predicates = new ArrayList<>();
@@ -96,17 +91,17 @@ public class CassandraStructureVersionFactory extends StructureVersionFactory {
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("structure_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("structure_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No StructureVersion found with id " + id + ".");
+        throw new GroundDBException("No StructureVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No StructureVersion found with id " + id + ".");
+        throw new GroundDBException("No StructureVersion found with id " + id + ".");
       }
 
       Map<String, GroundType> attributes = new HashMap<>();
@@ -114,25 +109,25 @@ public class CassandraStructureVersionFactory extends StructureVersionFactory {
       try {
         List<DbDataContainer> attributePredicates = new ArrayList<>();
         attributePredicates.add(new DbDataContainer("structure_version_id", GroundType.LONG, id));
-        QueryResults attributesSet = connection.equalitySelect("structure_version_attribute", DBClient.SELECT_STAR, attributePredicates);
+        QueryResults attributesSet = this.dbClient.equalitySelect("structure_version_attribute", DBClient.SELECT_STAR, attributePredicates);
 
         while (attributesSet.next()) {
           attributes.put(attributesSet.getString(1), GroundType.fromString(attributesSet.getString(2)));
         }
-      } catch (EmptyResultException eer) {
-        connection.abort();
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No StructureVersion attributes found for id " + id + ".");
+        throw new GroundDBException("No StructureVersion attributes found for id " + id + ".");
       }
 
       long structureId = resultSet.getLong(1);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved structure version " + id + " in structure " + structureId + ".");
 
       return StructureVersionFactory.construct(id, structureId, attributes);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraTagFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/cassandra/CassandraTagFactory.java
@@ -17,28 +17,31 @@ package edu.berkeley.ground.api.models.cassandra;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.models.TagFactory;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.*;
 
 public class CassandraTagFactory extends TagFactory {
-  public Map<String, Tag> retrieveFromDatabaseByVersionId(GroundDBConnection connection, long id) throws GroundException {
-    return this.retrieveFromDatabaseById(connection, id, "rich_version");
+  private final CassandraClient dbClient;
+
+  public CassandraTagFactory(CassandraClient dbClient) {
+    this.dbClient = dbClient;
   }
 
-  public Map<String, Tag> retrieveFromDatabaseByItemId(GroundDBConnection connection, long id) throws GroundException {
-    return this.retrieveFromDatabaseById(connection, id, "item");
+  public Map<String, Tag> retrieveFromDatabaseByVersionId(long id) throws GroundDBException {
+    return this.retrieveFromDatabaseById(id, "rich_version");
   }
 
-  private Map<String, Tag> retrieveFromDatabaseById(GroundDBConnection connectionPointer, long id, String keyPrefix) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
+  public Map<String, Tag> retrieveFromDatabaseByItemId(long id) throws GroundDBException {
+    return this.retrieveFromDatabaseById(id, "item");
+  }
 
+  private Map<String, Tag> retrieveFromDatabaseById(long id, String keyPrefix) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer(keyPrefix + "_id", GroundType.LONG, id));
 
@@ -46,8 +49,8 @@ public class CassandraTagFactory extends TagFactory {
 
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect(keyPrefix + "_tag", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
+      resultSet = this.dbClient.equalitySelect(keyPrefix + "_tag", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
       // this means that there are no tags
       return result;
     }
@@ -67,16 +70,15 @@ public class CassandraTagFactory extends TagFactory {
     return result;
   }
 
-  public List<Long> getVersionIdsByTag(GroundDBConnection connection, String tag) throws GroundException {
-    return this.getIdsByTag(connection, tag, "rich_version");
+  public List<Long> getVersionIdsByTag(String tag) throws GroundDBException {
+    return this.getIdsByTag(tag, "rich_version");
   }
 
-  public List<Long> getItemIdsByTag(GroundDBConnection connection, String tag) throws GroundException {
-    return this.getIdsByTag(connection, tag, "item");
+  public List<Long> getItemIdsByTag(String tag) throws GroundDBException {
+    return this.getIdsByTag(tag, "item");
   }
 
-  private List<Long> getIdsByTag(GroundDBConnection connectionPointer, String tag, String keyPrefix) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
+  private List<Long> getIdsByTag(String tag, String keyPrefix) throws GroundDBException {
     List<Long> result = new ArrayList<>();
 
     List<DbDataContainer> predicates = new ArrayList<>();
@@ -87,8 +89,8 @@ public class CassandraTagFactory extends TagFactory {
 
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect(keyPrefix + "_tag", projections, predicates);
-    } catch (EmptyResultException eer) {
+      resultSet = this.dbClient.equalitySelect(keyPrefix + "_tag", projections, predicates);
+    } catch (EmptyResultException e) {
       // this means that there are no tags
       return result;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jEdgeVersionFactory.java
@@ -21,9 +21,8 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.neo4j.driver.internal.value.StringValue;
@@ -38,11 +37,11 @@ import java.util.stream.Collectors;
 
 public class Neo4jEdgeVersionFactory extends EdgeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jEdgeVersionFactory.class);
-  private Neo4jClient dbClient;
-  private IdGenerator idGenerator;
+  private final Neo4jClient dbClient;
+  private final IdGenerator idGenerator;
 
-  private Neo4jEdgeFactory edgeFactory;
-  private Neo4jRichVersionFactory richVersionFactory;
+  private final Neo4jEdgeFactory edgeFactory;
+  private final Neo4jRichVersionFactory richVersionFactory;
 
   public Neo4jEdgeVersionFactory(Neo4jEdgeFactory edgeFactory, Neo4jRichVersionFactory richVersionFactory, Neo4jClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -58,9 +57,7 @@ public class Neo4jEdgeVersionFactory extends EdgeVersionFactory {
                             long edgeId,
                             long fromId,
                             long toId,
-                            List<Long> parentIds) throws GroundException {
-
-    Neo4jConnection connection = this.dbClient.getConnection();
+                            List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = idGenerator.generateVersionId();
@@ -73,50 +70,48 @@ public class Neo4jEdgeVersionFactory extends EdgeVersionFactory {
       insertions.add(new DbDataContainer("endpoint_one", GroundType.LONG, fromId));
       insertions.add(new DbDataContainer("endpoint_two", GroundType.LONG, toId));
 
-      connection.addVertex("EdgeVersion", insertions);
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.dbClient.addVertex("EdgeVersion", insertions);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
-      connection.addEdge("EdgeVersionConnection", fromId, id, new ArrayList<>());
-      connection.addEdge("EdgeVersionConnection", id, toId, new ArrayList<>());
+      this.dbClient.addEdge("EdgeVersionConnection", fromId, id, new ArrayList<>());
+      this.dbClient.addEdge("EdgeVersionConnection", id, toId, new ArrayList<>());
 
-      this.edgeFactory.update(connection, edgeId, id, parentIds);
+      this.edgeFactory.update(edgeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created edge version " + id + " in edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
       throw e;
     }
   }
 
-  public EdgeVersion retrieveFromDatabase(long id) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public EdgeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       Record versionRecord;
       try {
-        versionRecord = connection.getVertex(predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No EdgeVersion found with id " + id + ".");
+        versionRecord = this.dbClient.getVertex(predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No EdgeVersion found with id " + id + ".");
       }
 
       long edgeId = versionRecord.get("v").asNode() .get("edge_id").asLong();
       long fromId = versionRecord.get("v").asNode().get("endpoint_one").asLong();
       long toId = versionRecord.get("v").asNode().get("endpoint_two").asLong();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved edge version " + id + " in edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeFactory.java
@@ -19,12 +19,10 @@ import edu.berkeley.ground.api.models.NodeFactory;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.neo4j.Neo4jItemFactory;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.neo4j.driver.internal.value.StringValue;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class Neo4jNodeFactory extends NodeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jNodeFactory.class);
-  private Neo4jClient dbClient;
-  private Neo4jItemFactory itemFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public Neo4jNodeFactory(Neo4jItemFactory itemFactory, Neo4jClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,9 +47,7 @@ public class Neo4jNodeFactory extends NodeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Node create(String name, Map<String, Tag> tags) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public Node create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
@@ -59,59 +55,56 @@ public class Neo4jNodeFactory extends NodeFactory {
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("id", GroundType.LONG, uniqueId));
 
-      connection.addVertex("Node", insertions);
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.dbClient.addVertex("Node", insertions);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created node " + name + ".");
 
       return NodeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public List<Long> getLeaves(String name) throws GroundException {
+  public List<Long> getLeaves(String name) throws GroundDBException {
     Node node = this.retrieveFromDatabase(name);
 
-    Neo4jConnection connection = this.dbClient.getConnection();
-    List<Long> leaves = this.itemFactory.getLeaves(connection, node.getId());
-    connection.commit();
+    List<Long> leaves = this.itemFactory.getLeaves(node.getId());
+    this.dbClient.commit();
 
     return leaves;
   }
 
-  public Node retrieveFromDatabase(String name) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public Node retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       Record record;
       try {
-        record = connection.getVertex("Node", predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No Node found with name " + name + ".");
+        record = this.dbClient.getVertex("Node", predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No Node found with name " + name + ".");
       }
 
       long id = record.get("v").asNode().get("id").asLong();
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved node " + name + ".");
 
       return NodeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeVersionFactory.java
@@ -21,9 +21,8 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.neo4j.driver.internal.value.StringValue;
@@ -38,11 +37,11 @@ import java.util.stream.Collectors;
 
 public class Neo4jNodeVersionFactory extends NodeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jNodeVersionFactory.class);
-  private Neo4jClient dbClient;
-  private IdGenerator idGenerator;
+  private final Neo4jClient dbClient;
+  private final IdGenerator idGenerator;
 
-  private Neo4jNodeFactory nodeFactory;
-  private Neo4jRichVersionFactory richVersionFactory;
+  private final Neo4jNodeFactory nodeFactory;
+  private final Neo4jRichVersionFactory richVersionFactory;
 
   public Neo4jNodeVersionFactory(Neo4jNodeFactory nodeFactory, Neo4jRichVersionFactory richVersionFactory, Neo4jClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -56,9 +55,7 @@ public class Neo4jNodeVersionFactory extends NodeVersionFactory {
                             String reference,
                             Map<String, String> referenceParameters,
                             long nodeId,
-                            List<Long> parentIds) throws GroundException {
-
-    Neo4jConnection connection = this.dbClient.getConnection();
+                            List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
@@ -70,71 +67,61 @@ public class Neo4jNodeVersionFactory extends NodeVersionFactory {
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
       insertions.add(new DbDataContainer("node_id", GroundType.LONG, nodeId));
 
-      connection.addVertex("NodeVersion", insertions);
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.dbClient.addVertex("NodeVersion", insertions);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
-      this.nodeFactory.update(connection, nodeId, id, parentIds);
+      this.nodeFactory.update(nodeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
 
       LOGGER.info("Created node version " + id + " in node " + nodeId + ".");
 
       return NodeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, nodeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public NodeVersion retrieveFromDatabase(long id) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public NodeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       Record record;
       try {
-        record = connection.getVertex(predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No NodeVersion found with id " + id + ".");
+        record = this.dbClient.getVertex(predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No NodeVersion found with id " + id + ".");
       }
 
       long nodeId = record.get("v").asNode(). get("node_id").asLong();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved node version " + id + " in node " + nodeId + ".");
 
       return NodeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), nodeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public List<Long> getTransitiveClosure(long nodeVersionId) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-    try {
-      List<Long> result = connection.transitiveClosure(nodeVersionId);
+  public List<Long> getTransitiveClosure(long nodeVersionId) {
+    List<Long> result = this.dbClient.transitiveClosure(nodeVersionId);
 
-      connection.commit();
-      return result;
-    } catch (GroundException e) {
-      connection.abort();
-
-      throw e;
-    }
+    this.dbClient.commit();
+    return result;
   }
 
-  public List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameRegex) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-    List<Long> result = connection.adjacentNodes(nodeVersionId, edgeNameRegex);
+  public List<Long> getAdjacentNodes(long nodeVersionId, String edgeNameRegex) {
+    List<Long> result = this.dbClient.adjacentNodes(nodeVersionId, edgeNameRegex);
 
-    connection.commit();
+    this.dbClient.commit();
     return result;
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jRichVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jRichVersionFactory.java
@@ -19,12 +19,10 @@ import edu.berkeley.ground.api.models.RichVersionFactory;
 import edu.berkeley.ground.api.models.StructureVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import org.neo4j.driver.internal.value.NullValue;
 import org.neo4j.driver.internal.value.StringValue;
@@ -33,23 +31,24 @@ import org.neo4j.driver.v1.Record;
 import java.util.*;
 
 public class Neo4jRichVersionFactory extends RichVersionFactory {
-  private Neo4jStructureVersionFactory structureVersionFactory;
-  private Neo4jTagFactory tagFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jStructureVersionFactory structureVersionFactory;
+  private final Neo4jTagFactory tagFactory;
 
-  public Neo4jRichVersionFactory(Neo4jStructureVersionFactory structureVersionFactory, Neo4jTagFactory tagFactory) {
+  public Neo4jRichVersionFactory(Neo4jClient dbClient,
+                                 Neo4jStructureVersionFactory structureVersionFactory,
+                                 Neo4jTagFactory tagFactory) {
+    this.dbClient = dbClient;
     this.structureVersionFactory = structureVersionFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer,
-                                 long id,
+  public void insertIntoDatabase(long id,
                                  Map<String, Tag> tags,
                                  long structureVersionId,
                                  String reference,
                                  Map<String, String> referenceParameters
-  ) throws GroundException {
-    Neo4jConnection connection = (Neo4jConnection) connectionPointer;
-
+  ) throws GroundDBException {
     if (structureVersionId != -1) {
       StructureVersion structureVersion = this.structureVersionFactory.retrieveFromDatabase(structureVersionId);
       RichVersionFactory.checkStructureTags(structureVersion, tags);
@@ -63,17 +62,17 @@ public class Neo4jRichVersionFactory extends RichVersionFactory {
       insertions.add(new DbDataContainer("pkey", GroundType.STRING, key));
       insertions.add(new DbDataContainer("value", GroundType.STRING, value));
 
-      connection.addVertexAndEdge("RichVersionExternalParameter", insertions, "RichVersionExternalParameterConnection", id, new ArrayList<>());
+      this.dbClient.addVertexAndEdge("RichVersionExternalParameter", insertions, "RichVersionExternalParameterConnection", id, new ArrayList<>());
 
       insertions.clear();
     }
 
     if (structureVersionId != -1) {
-      connection.setProperty(id, "structure_id", structureVersionId, false);
+      this.dbClient.setProperty(id, "structure_id", structureVersionId, false);
     }
 
     if (reference != null) {
-      connection.setProperty(id, "reference", reference, true);
+      this.dbClient.setProperty(id, "reference", reference, true);
     }
 
     for (String key : tags.keySet()) {
@@ -91,29 +90,27 @@ public class Neo4jRichVersionFactory extends RichVersionFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.addVertexAndEdge("RichVersionTag", tagInsertion, "RichVersionTagConnection", id, new ArrayList<>());
+      this.dbClient.addVertexAndEdge("RichVersionTag", tagInsertion, "RichVersionTagConnection", id, new ArrayList<>());
       tagInsertion.clear();
     }
   }
 
-  public RichVersion retrieveFromDatabase(GroundDBConnection connectionPointer, long id) throws GroundException {
-    Neo4jConnection connection = (Neo4jConnection) connectionPointer;
-
+  public RichVersion retrieveFromDatabase(long id) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("id", GroundType.LONG, id));
     Record record;
 
     try {
-      record = connection.getVertex(predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No RichVersion found with id " + id + ".");
+      record = this.dbClient.getVertex(predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No RichVersion found with id " + id + ".");
     }
 
     List<String> returnFields = new ArrayList<>();
     returnFields.add("pkey");
     returnFields.add("value");
 
-    List<Record> parameterVertices = connection.getAdjacentVerticesByEdgeLabel("RichVersionExternalParameterConnection", id, returnFields);
+    List<Record> parameterVertices = this.dbClient.getAdjacentVerticesByEdgeLabel("RichVersionExternalParameterConnection", id, returnFields);
     Map<String, String> referenceParameters = new HashMap<>();
 
     if (!parameterVertices.isEmpty()) {
@@ -122,7 +119,7 @@ public class Neo4jRichVersionFactory extends RichVersionFactory {
       }
     }
 
-    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(connectionPointer, id);
+    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(id);
 
     String reference;
     if (record.get("v").asNode().get("reference") instanceof NullValue) {

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jStructureVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/neo4j/Neo4jStructureVersionFactory.java
@@ -19,9 +19,8 @@ import edu.berkeley.ground.api.models.StructureVersionFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.neo4j.driver.internal.value.StringValue;
@@ -33,10 +32,10 @@ import java.util.*;
 
 public class Neo4jStructureVersionFactory extends StructureVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jStructureVersionFactory.class);
-  private Neo4jClient dbClient;
-  private Neo4jStructureFactory structureFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jStructureFactory structureFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public Neo4jStructureVersionFactory(Neo4jClient dbClient, Neo4jStructureFactory structureFactory, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -44,9 +43,7 @@ public class Neo4jStructureVersionFactory extends StructureVersionFactory {
     this.idGenerator = idGenerator;
   }
 
-  public StructureVersion create(long structureId, Map<String, GroundType> attributes, List<Long> parentIds) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public StructureVersion create(long structureId, Map<String, GroundType> attributes, List<Long> parentIds) throws GroundDBException {
     try {
       long id = this.idGenerator.generateVersionId();
 
@@ -54,7 +51,7 @@ public class Neo4jStructureVersionFactory extends StructureVersionFactory {
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
       insertions.add(new DbDataContainer("structure_id", GroundType.LONG, structureId));
 
-      connection.addVertex("StructureVersion", insertions);
+      this.dbClient.addVertex("StructureVersion", insertions);
 
       for (String key : attributes.keySet()) {
         List<DbDataContainer> itemInsertions = new ArrayList<>();
@@ -62,24 +59,22 @@ public class Neo4jStructureVersionFactory extends StructureVersionFactory {
         itemInsertions.add(new DbDataContainer("skey", GroundType.STRING, key));
         itemInsertions.add(new DbDataContainer("stype", GroundType.STRING, attributes.get(key).toString()));
 
-        connection.addVertexAndEdge("StructureVersionItem", itemInsertions, "StructureVersionItemConnection", id, new ArrayList<>());
+        this.dbClient.addVertexAndEdge("StructureVersionItem", itemInsertions, "StructureVersionItemConnection", id, new ArrayList<>());
       }
 
-      this.structureFactory.update(connection, structureId, id, parentIds);
+      this.structureFactory.update(structureId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created structure version " + id + " in structure " + structureId + ".");
 
       return StructureVersionFactory.construct(id, structureId, attributes);
-    } catch (GroundException ge) {
-      connection.abort();
+    } catch (GroundDBException ge) {
+      this.dbClient.abort();
       throw ge;
     }
   }
 
-  public StructureVersion retrieveFromDatabase(long id) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public StructureVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
@@ -87,16 +82,16 @@ public class Neo4jStructureVersionFactory extends StructureVersionFactory {
       long structureId;
 
       try {
-        structureId = connection .getVertex(predicates).get("v").asNode().get("structure_id").asLong();
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No StructureVersion found with id " + id + ".");
+        structureId = this.dbClient.getVertex(predicates).get("v").asNode().get("structure_id").asLong();
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No StructureVersion found with id " + id + ".");
       }
       List<String> returnFields = new ArrayList<>();
       returnFields.add("svid");
       returnFields.add("skey");
       returnFields.add("stype");
 
-      List<Record> edges = connection.getAdjacentVerticesByEdgeLabel("StructureVersionItemConnection", id, returnFields);
+      List<Record> edges = this.dbClient.getAdjacentVerticesByEdgeLabel("StructureVersionItemConnection", id, returnFields);
       Map<String, GroundType> attributes = new HashMap<>();
 
 
@@ -104,15 +99,14 @@ public class Neo4jStructureVersionFactory extends StructureVersionFactory {
         attributes.put(Neo4jClient.getStringFromValue((StringValue) record.get("skey")), GroundType.fromString(Neo4jClient.getStringFromValue((StringValue) record.get("stype"))));
       }
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved structure version " + id + " in structure " + structureId + ".");
 
       return StructureVersionFactory.construct(id, structureId, attributes);
-    } catch (GroundException ge) {
-      connection.abort();
+    } catch (GroundDBException ge) {
+      this.dbClient.abort();
 
       throw ge;
     }
   }
-
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresEdgeFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.postgres.PostgresItemFactory;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class PostgresEdgeFactory extends EdgeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresEdgeFactory.class);
-  private PostgresClient dbClient;
-  private PostgresItemFactory itemFactory;
+  private final PostgresClient dbClient;
+  private final PostgresItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresEdgeFactory(PostgresItemFactory itemFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,33 +47,29 @@ public class PostgresEdgeFactory extends EdgeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Edge create(String name, Map<String, Tag> tags) throws GroundException {
-    PostgresConnection connection = dbClient.getConnection();
-
+  public Edge create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("edge", insertions);
+      this.dbClient.insert("edge", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created edge " + name + ".");
       return EdgeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public Edge retrieveFromDatabase(String name) throws GroundException {
-    PostgresConnection connection = dbClient.getConnection();
-
+  public Edge retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
 
@@ -83,26 +77,26 @@ public class PostgresEdgeFactory extends EdgeFactory {
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("edge", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No Edge found with name " + name + ".");
+        resultSet = this.dbClient.equalitySelect("edge", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No Edge found with name " + name + ".");
       }
 
       long id = resultSet.getLong(1);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved edge " + name + ".");
 
       return EdgeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresEdgeVersionFactory.java
@@ -19,10 +19,9 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -35,11 +34,11 @@ import java.util.stream.Collectors;
 
 public class PostgresEdgeVersionFactory extends EdgeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresEdgeVersionFactory.class);
-  private PostgresClient dbClient;
-  private PostgresEdgeFactory edgeFactory;
-  private PostgresRichVersionFactory richVersionFactory;
+  private final PostgresClient dbClient;
+  private final PostgresEdgeFactory edgeFactory;
+  private final PostgresRichVersionFactory richVersionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresEdgeVersionFactory(PostgresEdgeFactory edgeFactory, PostgresRichVersionFactory richVersionFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -55,16 +54,14 @@ public class PostgresEdgeVersionFactory extends EdgeVersionFactory {
                             long edgeId,
                             long fromId,
                             long toId,
-                            List<Long> parentIds) throws GroundException {
-
-    PostgresConnection connection = this.dbClient.getConnection();
+                            List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
 
       tags = tags.values().stream().collect(Collectors.toMap(Tag::getKey, tag -> new Tag(id, tag.getKey(), tag.getValue(), tag.getValueType())));
 
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
@@ -72,45 +69,43 @@ public class PostgresEdgeVersionFactory extends EdgeVersionFactory {
       insertions.add(new DbDataContainer("from_node_version_id", GroundType.LONG, fromId));
       insertions.add(new DbDataContainer("to_node_version_id", GroundType.LONG, toId));
 
-      connection.insert("edge_version", insertions);
+      this.dbClient.insert("edge_version", insertions);
 
-      this.edgeFactory.update(connection, edgeId, id, parentIds);
+      this.edgeFactory.update(edgeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created edge version " + id + " in edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
       throw e;
     }
   }
 
-  public EdgeVersion retrieveFromDatabase(long id) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public EdgeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("edge_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No EdgeVersion found with id " + id + ".");
+        resultSet = this.dbClient.equalitySelect("edge_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No EdgeVersion found with id " + id + ".");
       }
       long edgeId = resultSet.getLong(2);
       long fromId = resultSet.getLong(3);
       long toId = resultSet.getLong(4);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved edge version " + id + " in edge " + edgeId + ".");
 
       return EdgeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), edgeId, fromId, toId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresGraphVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresGraphVersionFactory.java
@@ -22,10 +22,9 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,11 +37,11 @@ import java.util.stream.Collectors;
 
 public class PostgresGraphVersionFactory extends GraphVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresGraphVersionFactory.class);
-  private PostgresClient dbClient;
-  private PostgresGraphFactory graphFactory;
-  private PostgresRichVersionFactory richVersionFactory;
+  private final PostgresClient dbClient;
+  private final PostgresGraphFactory graphFactory;
+  private final PostgresRichVersionFactory richVersionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresGraphVersionFactory(PostgresGraphFactory graphFactory, PostgresRichVersionFactory richVersionFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -57,49 +56,45 @@ public class PostgresGraphVersionFactory extends GraphVersionFactory {
                              Map<String, String> referenceParameters,
                              long graphId,
                              List<Long> edgeVersionIds,
-                             List<Long> parentIds) throws GroundException {
-
-    PostgresConnection connection = this.dbClient.getConnection();
+                             List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
 
       tags = tags.values().stream().collect(Collectors.toMap(Tag::getKey, tag -> new Tag(id, tag.getKey(), tag.getValue(), tag.getValueType())));
 
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
       insertions.add(new DbDataContainer("graph_id", GroundType.LONG, graphId));
 
-      connection.insert("graph_version", insertions);
+      this.dbClient.insert("graph_version", insertions);
 
       for (long edgeVersionId : edgeVersionIds) {
         List<DbDataContainer> edgeInsertion = new ArrayList<>();
         edgeInsertion.add(new DbDataContainer("graph_version_id", GroundType.LONG, id));
         edgeInsertion.add(new DbDataContainer("edge_version_id", GroundType.LONG, edgeVersionId));
 
-        connection.insert("graph_version_edge", edgeInsertion);
+        this.dbClient.insert("graph_version_edge", edgeInsertion);
       }
 
-      this.graphFactory.update(connection, graphId, id, parentIds);
+      this.graphFactory.update(graphId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created graph version " + id + " in graph " + graphId + ".");
 
       return GraphVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, graphId, edgeVersionIds);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public GraphVersion retrieveFromDatabase(long id) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public GraphVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
@@ -109,9 +104,9 @@ public class PostgresGraphVersionFactory extends GraphVersionFactory {
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("graph_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No GraphVersion found with id " + id + ".");
+        resultSet = this.dbClient.equalitySelect("graph_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No GraphVersion found with id " + id + ".");
       }
 
       long graphId = resultSet.getLong(2);
@@ -119,21 +114,21 @@ public class PostgresGraphVersionFactory extends GraphVersionFactory {
       QueryResults edgeSet;
       List<Long> edgeVersionIds = new ArrayList<>();
       try {
-        edgeSet = connection.equalitySelect("graph_version_edge", DBClient.SELECT_STAR, edgePredicate);
+        edgeSet = this.dbClient.equalitySelect("graph_version_edge", DBClient.SELECT_STAR, edgePredicate);
 
         do {
           edgeVersionIds.add(edgeSet.getLong(2));
         } while (edgeSet.next());
-      } catch (EmptyResultException eer) {
+      } catch (EmptyResultException e) {
         // do nothing; this just means that there are no edges in the GraphVersion
       }
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved graph version " + id + " in graph " + graphId + ".");
 
       return GraphVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), graphId, edgeVersionIds);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresNodeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresNodeFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.postgres.PostgresItemFactory;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class PostgresNodeFactory extends NodeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresNodeFactory.class);
-  private PostgresClient dbClient;
-  private PostgresItemFactory itemFactory;
+  private final PostgresClient dbClient;
+  private final PostgresItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresNodeFactory(PostgresItemFactory itemFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,71 +47,66 @@ public class PostgresNodeFactory extends NodeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Node create(String name, Map<String, Tag> tags) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public Node create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("node", insertions);
+      this.dbClient.insert("node", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created node " + name + ".");
 
       return NodeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public List<Long> getLeaves(String name) throws GroundException {
+  public List<Long> getLeaves(String name) throws GroundDBException {
     Node node = this.retrieveFromDatabase(name);
 
-    PostgresConnection connection = this.dbClient.getConnection();
-    List<Long> leaves = this.itemFactory.getLeaves(connection, node.getId());
-    connection.commit();
+    List<Long> leaves = this.itemFactory.getLeaves(node.getId());
+    this.dbClient.commit();
 
     return leaves;
   }
 
 
-  public Node retrieveFromDatabase(String name) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public Node retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("node", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No Node found with name " + name + ".");
+        resultSet = this.dbClient.equalitySelect("node", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No Node found with name " + name + ".");
       }
 
       long id = resultSet.getLong(1);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved node " + name + ".");
 
       return NodeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresRichVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresRichVersionFactory.java
@@ -21,38 +21,37 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.postgres.PostgresVersionFactory;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
+import edu.berkeley.ground.db.PostgresClient;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.*;
 
 public class PostgresRichVersionFactory extends RichVersionFactory {
-  private PostgresVersionFactory versionFactory;
-  private PostgresStructureVersionFactory structureVersionFactory;
-  private PostgresTagFactory tagFactory;
+  private final PostgresClient dbClient;
+  private final PostgresVersionFactory versionFactory;
+  private final PostgresStructureVersionFactory structureVersionFactory;
+  private final PostgresTagFactory tagFactory;
 
-  public PostgresRichVersionFactory(PostgresVersionFactory versionFactory,
+  public PostgresRichVersionFactory(PostgresClient dbClient,
+                                    PostgresVersionFactory versionFactory,
                                     PostgresStructureVersionFactory structureVersionFactory,
                                     PostgresTagFactory tagFactory) {
 
+    this.dbClient = dbClient;
     this.versionFactory = versionFactory;
     this.structureVersionFactory = structureVersionFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer,
-                                 long id,
+  public void insertIntoDatabase(long id,
                                  Map<String, Tag> tags,
                                  long structureVersionId,
                                  String reference,
-                                 Map<String, String> referenceParameters) throws GroundException {
-    PostgresConnection connection = (PostgresConnection) connectionPointer;
-
-    this.versionFactory.insertIntoDatabase(connection, id);
+                                 Map<String, String> referenceParameters) throws GroundDBException {
+    this.versionFactory.insertIntoDatabase(id);
 
     if (structureVersionId != -1) {
       StructureVersion structureVersion = this.structureVersionFactory.retrieveFromDatabase(structureVersionId);
@@ -64,7 +63,7 @@ public class PostgresRichVersionFactory extends RichVersionFactory {
     insertions.add(new DbDataContainer("structure_version_id", GroundType.LONG, structureVersionId));
     insertions.add(new DbDataContainer("reference", GroundType.STRING, reference));
 
-    connection.insert("rich_version", insertions);
+    this.dbClient.insert("rich_version", insertions);
 
     for (String key : tags.keySet()) {
       Tag tag = tags.get(key);
@@ -81,7 +80,7 @@ public class PostgresRichVersionFactory extends RichVersionFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.insert("rich_version_tag", tagInsertion);
+      this.dbClient.insert("rich_version_tag", tagInsertion);
     }
 
     for (String key : referenceParameters.keySet()) {
@@ -91,21 +90,19 @@ public class PostgresRichVersionFactory extends RichVersionFactory {
       parameterInsertion.add(new DbDataContainer("key", GroundType.STRING, key));
       parameterInsertion.add(new DbDataContainer("value", GroundType.STRING, referenceParameters.get(key)));
 
-      connection.insert("rich_version_external_parameter", parameterInsertion);
+      this.dbClient.insert("rich_version_external_parameter", parameterInsertion);
     }
   }
 
-  public RichVersion retrieveFromDatabase(GroundDBConnection connectionPointer, long id) throws GroundException {
-    PostgresConnection connection = (PostgresConnection) connectionPointer;
-
+  public RichVersion retrieveFromDatabase(long id) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect("rich_version", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No RichVersion found with id " + id + ".");
+      resultSet = this.dbClient.equalitySelect("rich_version", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No RichVersion found with id " + id + ".");
     }
 
     List<DbDataContainer> parameterPredicates = new ArrayList<>();
@@ -113,16 +110,16 @@ public class PostgresRichVersionFactory extends RichVersionFactory {
     Map<String, String> referenceParameters = new HashMap<>();
 
     try {
-      QueryResults parameterSet = connection.equalitySelect("rich_version_external_parameter", DBClient.SELECT_STAR, parameterPredicates);
+      QueryResults parameterSet = this.dbClient.equalitySelect("rich_version_external_parameter", DBClient.SELECT_STAR, parameterPredicates);
 
       do {
         referenceParameters.put(parameterSet.getString(2), parameterSet.getString(3));
       } while (parameterSet.next());
-    } catch (EmptyResultException eer) {
+    } catch (EmptyResultException e) {
       // do nothing; there are no referenceParameters
     }
 
-    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(connection, id);
+    Map<String, Tag> tags = tagFactory.retrieveFromDatabaseByVersionId(id);
 
     String reference = resultSet.getString(3);
     long structureVersionId = resultSet.getLong(2);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresStructureFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresStructureFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.postgres.PostgresItemFactory;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class PostgresStructureFactory extends StructureFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresStructureFactory.class);
-  private PostgresClient dbClient;
-  private PostgresItemFactory itemFactory;
+  private final PostgresClient dbClient;
+  private final PostgresItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresStructureFactory(PostgresItemFactory itemFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,70 +47,65 @@ public class PostgresStructureFactory extends StructureFactory {
     this.idGenerator = idGenerator;
   }
 
-  public Structure create(String name, Map<String, Tag> tags) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public Structure create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("structure", insertions);
+      this.dbClient.insert("structure", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created structure " + name + ".");
 
       return StructureFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public List<Long> getLeaves(String name) throws GroundException {
+  public List<Long> getLeaves(String name) throws GroundDBException {
     Structure structure = this.retrieveFromDatabase(name);
 
-    PostgresConnection connection = this.dbClient.getConnection();
-    List<Long> leaves = this.itemFactory.getLeaves(connection, structure.getId());
-    connection.commit();
+    List<Long> leaves = this.itemFactory.getLeaves(structure.getId());
+    this.dbClient.commit();
 
     return leaves;
   }
 
-  public Structure retrieveFromDatabase(String name) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public Structure retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("structure", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No Structure found with name " + name + ".");
+        resultSet = this.dbClient.equalitySelect("structure", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No Structure found with name " + name + ".");
       }
 
       long id = resultSet.getLong(1);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved structure " + name + ".");
 
       return StructureFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresStructureVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/models/postgres/PostgresStructureVersionFactory.java
@@ -21,10 +21,9 @@ import edu.berkeley.ground.api.versions.postgres.PostgresVersionFactory;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -34,11 +33,11 @@ import java.util.*;
 
 public class PostgresStructureVersionFactory extends StructureVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresStructureVersionFactory.class);
-  private PostgresClient dbClient;
-  private PostgresStructureFactory structureFactory;
-  private PostgresVersionFactory versionFactory;
+  private final PostgresClient dbClient;
+  private final PostgresStructureFactory structureFactory;
+  private final PostgresVersionFactory versionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresStructureVersionFactory(PostgresStructureFactory structureFactory, PostgresVersionFactory versionFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,19 +48,17 @@ public class PostgresStructureVersionFactory extends StructureVersionFactory {
 
   public StructureVersion create(long structureId,
                                  Map<String, GroundType> attributes,
-                                 List<Long> parentIds) throws GroundException {
-
-    PostgresConnection connection = this.dbClient.getConnection();
+                                 List<Long> parentIds) throws GroundDBException {
 
     long id = this.idGenerator.generateVersionId();
 
-    this.versionFactory.insertIntoDatabase(connection, id);
+    this.versionFactory.insertIntoDatabase(id);
 
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("id", GroundType.LONG, id));
     insertions.add(new DbDataContainer("structure_id", GroundType.LONG, structureId));
 
-    connection.insert("structure_version", insertions);
+    this.dbClient.insert("structure_version", insertions);
 
     for (String key : attributes.keySet()) {
       List<DbDataContainer> itemInsertions = new ArrayList<>();
@@ -69,27 +66,25 @@ public class PostgresStructureVersionFactory extends StructureVersionFactory {
       itemInsertions.add(new DbDataContainer("key", GroundType.STRING, key));
       itemInsertions.add(new DbDataContainer("type", GroundType.STRING, attributes.get(key).toString()));
 
-      connection.insert("structure_version_attribute", itemInsertions);
+      this.dbClient.insert("structure_version_attribute", itemInsertions);
     }
 
-    this.structureFactory.update(connection, structureId, id, parentIds);
+    this.structureFactory.update(structureId, id, parentIds);
 
-    connection.commit();
+    this.dbClient.commit();
     LOGGER.info("Created structure version " + id + " in structure " + structureId + ".");
 
     return StructureVersionFactory.construct(id, structureId, attributes);
   }
 
-  public StructureVersion retrieveFromDatabase(long id) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public StructureVersion retrieveFromDatabase(long id) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("id", GroundType.LONG, id));
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect("structure_version", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No StructureVersion found with id " + id + ".");
+      resultSet = this.dbClient.equalitySelect("structure_version", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No StructureVersion found with id " + id + ".");
     }
 
     List<DbDataContainer> attributePredicates = new ArrayList<>();
@@ -97,9 +92,9 @@ public class PostgresStructureVersionFactory extends StructureVersionFactory {
 
     QueryResults attributesSet;
     try {
-      attributesSet = connection.equalitySelect("structure_version_attribute", DBClient.SELECT_STAR, attributePredicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No attributes found for StructureVersion with id " + id + ".");
+      attributesSet = this.dbClient.equalitySelect("structure_version_attribute", DBClient.SELECT_STAR, attributePredicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No attributes found for StructureVersion with id " + id + ".");
     }
 
     Map<String, GroundType> attributes = new HashMap<>();
@@ -110,7 +105,7 @@ public class PostgresStructureVersionFactory extends StructureVersionFactory {
 
     long structureId = resultSet.getLong(2);
 
-    connection.commit();
+    this.dbClient.commit();
     LOGGER.info("Retrieved structure version " + id + " in structure " + structureId + ".");
 
     return StructureVersionFactory.construct(id, structureId, attributes);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeFactory.java
@@ -15,18 +15,17 @@
 package edu.berkeley.ground.api.usage;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class LineageEdgeFactory {
-  public abstract LineageEdge create(String name, Map<String, Tag> tags) throws GroundException;
+  public abstract LineageEdge create(String name, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract LineageEdge retrieveFromDatabase(String name) throws GroundException;
+  public abstract LineageEdge retrieveFromDatabase(String name) throws GroundDBException;
 
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
   public static LineageEdge construct(long id, String name, Map<String, Tag> tags) {
     return new LineageEdge(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeFactory.java
@@ -15,17 +15,17 @@
 package edu.berkeley.ground.api.usage;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class LineageEdgeFactory {
-  public abstract LineageEdge create(String name, Map<String, Tag> tags) throws GroundDBException;
+  public abstract LineageEdge create(String name, Map<String, Tag> tags) throws GroundException;
 
-  public abstract LineageEdge retrieveFromDatabase(String name) throws GroundDBException;
+  public abstract LineageEdge retrieveFromDatabase(String name) throws GroundException;
 
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
   public static LineageEdge construct(long id, String name, Map<String, Tag> tags) {
     return new LineageEdge(id, name, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeVersionFactory.java
@@ -15,7 +15,7 @@
 package edu.berkeley.ground.api.usage;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
@@ -28,9 +28,9 @@ public abstract class LineageEdgeVersionFactory {
                                             long fromId,
                                             long toId,
                                             long lineageEdgeId,
-                                            List<Long> parentIds) throws GroundDBException;
+                                            List<Long> parentIds) throws GroundException;
 
-  public abstract LineageEdgeVersion retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract LineageEdgeVersion retrieveFromDatabase(long id) throws GroundException;
 
   protected static LineageEdgeVersion construct(long id,
                                                 Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/LineageEdgeVersionFactory.java
@@ -15,7 +15,7 @@
 package edu.berkeley.ground.api.usage;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
@@ -28,9 +28,9 @@ public abstract class LineageEdgeVersionFactory {
                                             long fromId,
                                             long toId,
                                             long lineageEdgeId,
-                                            List<Long> parentIds) throws GroundException;
+                                            List<Long> parentIds) throws GroundDBException;
 
-  public abstract LineageEdgeVersion retrieveFromDatabase(long id) throws GroundException;
+  public abstract LineageEdgeVersion retrieveFromDatabase(long id) throws GroundDBException;
 
   protected static LineageEdgeVersion construct(long id,
                                                 Map<String, Tag> tags,

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.usage.LineageEdgeFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.cassandra.CassandraItemFactory;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class CassandraLineageEdgeFactory extends LineageEdgeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraLineageEdgeFactory.class);
-  private CassandraClient dbClient;
-  private CassandraItemFactory itemFactory;
+  private final CassandraClient dbClient;
+  private final CassandraItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraLineageEdgeFactory(CassandraItemFactory itemFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,68 +47,64 @@ public class CassandraLineageEdgeFactory extends LineageEdgeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("lineage_edge", insertions);
+      this.dbClient.insert("lineage_edge", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("lineage_edge", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("lineage_edge", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No LineageEdge found with name " + name + ".");
+        throw new GroundDBException("No LineageEdge found with name " + name + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No LineageEdge found with name " + name + ".");
+        throw new GroundDBException("No LineageEdge found with name " + name + ".");
       }
 
       long id = resultSet.getLong("item_id");
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/cassandra/CassandraLineageEdgeVersionFactory.java
@@ -21,12 +21,11 @@ import edu.berkeley.ground.api.usage.LineageEdgeVersion;
 import edu.berkeley.ground.api.usage.LineageEdgeVersionFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.db.CassandraClient;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.db.DBClient;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -39,11 +38,11 @@ import java.util.stream.Collectors;
 
 public class CassandraLineageEdgeVersionFactory extends LineageEdgeVersionFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraLineageEdgeVersionFactory.class);
-  private CassandraClient dbClient;
-  private CassandraLineageEdgeFactory lineageEdgeFactory;
-  private CassandraRichVersionFactory richVersionFactory;
+  private final CassandraClient dbClient;
+  private final CassandraLineageEdgeFactory lineageEdgeFactory;
+  private final CassandraRichVersionFactory richVersionFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public CassandraLineageEdgeVersionFactory(CassandraLineageEdgeFactory lineageEdgeFactory, CassandraRichVersionFactory richVersionFactory, CassandraClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -60,16 +59,14 @@ public class CassandraLineageEdgeVersionFactory extends LineageEdgeVersionFactor
                                    long fromId,
                                    long toId,
                                    long lineageEdgeId,
-                                   List<Long> parentIds) throws GroundException {
-
-    CassandraConnection connection = this.dbClient.getConnection();
+                                   List<Long> parentIds) throws GroundDBException {
 
     try {
       long id = this.idGenerator.generateVersionId();
 
       tags.values().stream().collect(Collectors.toMap(Tag::getKey, tag -> new Tag(id, tag.getKey(), tag.getValue(), tag.getValueType())));
 
-      this.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, reference, referenceParameters);
+      this.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, reference, referenceParameters);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("id", GroundType.LONG, id));
@@ -77,55 +74,53 @@ public class CassandraLineageEdgeVersionFactory extends LineageEdgeVersionFactor
       insertions.add(new DbDataContainer("from_rich_version_id", GroundType.LONG, fromId));
       insertions.add(new DbDataContainer("to_rich_version_id", GroundType.LONG, toId));
 
-      connection.insert("lineage_edge_version", insertions);
+      this.dbClient.insert("lineage_edge_version", insertions);
 
-      this.lineageEdgeFactory.update(connection, lineageEdgeId, id, parentIds);
+      this.lineageEdgeFactory.update(lineageEdgeId, id, parentIds);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created lineage edge version " + id + " in lineage edge " + lineageEdgeId + ".");
 
       return LineageEdgeVersionFactory.construct(id, tags, structureVersionId, reference, referenceParameters, fromId, toId, lineageEdgeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public LineageEdgeVersion retrieveFromDatabase(long id) throws GroundException {
-    CassandraConnection connection = this.dbClient.getConnection();
-
+  public LineageEdgeVersion retrieveFromDatabase(long id) throws GroundDBException {
     try {
-      RichVersion version = this.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion version = this.richVersionFactory.retrieveFromDatabase(id);
 
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("id", GroundType.LONG, id));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("lineage_edge_version", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        connection.abort();
+        resultSet = this.dbClient.equalitySelect("lineage_edge_version", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        this.dbClient.abort();
 
-        throw new GroundException("No LineageEdgeVersion found with id " + id + ".");
+        throw new GroundDBException("No LineageEdgeVersion found with id " + id + ".");
       }
 
       if (!resultSet.next()) {
-        connection.abort();
+        this.dbClient.abort();
 
-        throw new GroundException("No LineageEdgeVersion found with id " + id + ".");
+        throw new GroundDBException("No LineageEdgeVersion found with id " + id + ".");
       }
 
       long lineageEdgeId = resultSet.getLong("lineage_edge_id");
       long fromId = resultSet.getLong("from_rich_version_id");
       long toId = resultSet.getLong("to_rich_version_id");
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved lineage edge version " + id + " in lineage edge " + lineageEdgeId + ".");
 
       return LineageEdgeVersionFactory.construct(id, version.getTags(), version.getStructureVersionId(), version.getReference(), version.getParameters(), fromId, toId, lineageEdgeId);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/neo4j/Neo4jLineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/neo4j/Neo4jLineageEdgeFactory.java
@@ -19,12 +19,10 @@ import edu.berkeley.ground.api.usage.LineageEdge;
 import edu.berkeley.ground.api.usage.LineageEdgeFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.neo4j.Neo4jItemFactory;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.neo4j.driver.internal.value.StringValue;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class Neo4jLineageEdgeFactory extends LineageEdgeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jLineageEdgeFactory.class);
-  private Neo4jClient dbClient;
-  private Neo4jItemFactory itemFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public Neo4jLineageEdgeFactory(Neo4jItemFactory itemFactory, Neo4jClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,9 +47,7 @@ public class Neo4jLineageEdgeFactory extends LineageEdgeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
@@ -60,49 +56,47 @@ public class Neo4jLineageEdgeFactory extends LineageEdgeFactory {
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("id", GroundType.LONG, uniqueId));
 
-      connection.addVertex("LineageEdges", insertions);
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.dbClient.addVertex("LineageEdges", insertions);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
-    Neo4jConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       Record record;
       try {
-        record = connection.getVertex(predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No LineageEdge found with name " + name + ".");
+        record = this.dbClient.getVertex(predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No LineageEdge found with name " + name + ".");
       }
 
       long id = record.get("v").asNode().get("id").asLong();
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/usage/postgres/PostgresLineageEdgeFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/usage/postgres/PostgresLineageEdgeFactory.java
@@ -20,13 +20,11 @@ import edu.berkeley.ground.api.usage.LineageEdgeFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.postgres.PostgresItemFactory;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.PostgresClient;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import org.slf4j.Logger;
@@ -38,10 +36,10 @@ import java.util.Map;
 
 public class PostgresLineageEdgeFactory extends LineageEdgeFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresLineageEdgeFactory.class);
-  private PostgresClient dbClient;
-  private PostgresItemFactory itemFactory;
+  private final PostgresClient dbClient;
+  private final PostgresItemFactory itemFactory;
 
-  private IdGenerator idGenerator;
+  private final IdGenerator idGenerator;
 
   public PostgresLineageEdgeFactory(PostgresItemFactory itemFactory, PostgresClient dbClient, IdGenerator idGenerator) {
     this.dbClient = dbClient;
@@ -49,60 +47,56 @@ public class PostgresLineageEdgeFactory extends LineageEdgeFactory {
     this.idGenerator = idGenerator;
   }
 
-  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge create(String name, Map<String, Tag> tags) throws GroundDBException {
     try {
       long uniqueId = this.idGenerator.generateItemId();
 
-      this.itemFactory.insertIntoDatabase(connection, uniqueId, tags);
+      this.itemFactory.insertIntoDatabase(uniqueId, tags);
 
       List<DbDataContainer> insertions = new ArrayList<>();
       insertions.add(new DbDataContainer("name", GroundType.STRING, name));
       insertions.add(new DbDataContainer("item_id", GroundType.LONG, uniqueId));
 
-      connection.insert("lineage_edge", insertions);
+      this.dbClient.insert("lineage_edge", insertions);
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Created lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(uniqueId, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
-    PostgresConnection connection = this.dbClient.getConnection();
-
+  public LineageEdge retrieveFromDatabase(String name) throws GroundDBException {
     try {
       List<DbDataContainer> predicates = new ArrayList<>();
       predicates.add(new DbDataContainer("name", GroundType.STRING, name));
 
       QueryResults resultSet;
       try {
-        resultSet = connection.equalitySelect("lineage_edge", DBClient.SELECT_STAR, predicates);
-      } catch (EmptyResultException eer) {
-        throw new GroundException("No LineageEdge found with name " + name + ".");
+        resultSet = this.dbClient.equalitySelect("lineage_edge", DBClient.SELECT_STAR, predicates);
+      } catch (EmptyResultException e) {
+        throw new GroundDBException("No LineageEdge found with name " + name + ".");
       }
 
       long id = resultSet.getLong(1);
-      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(connection, id).getTags();
+      Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-      connection.commit();
+      this.dbClient.commit();
       LOGGER.info("Retrieved lineage edge " + name + ".");
 
       return LineageEdgeFactory.construct(id, name, tags);
-    } catch (GroundException e) {
-      connection.abort();
+    } catch (GroundDBException e) {
+      this.dbClient.abort();
 
       throw e;
     }
   }
 
-  public void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException {
-    this.itemFactory.update(connection, itemId, childId, parentIds);
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
+    this.itemFactory.update(itemId, childId, parentIds);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/GroundType.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/GroundType.java
@@ -17,7 +17,7 @@ package edu.berkeley.ground.api.versions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 public enum GroundType {
   STRING(String.class, "string"),
@@ -38,7 +38,7 @@ public enum GroundType {
   }
 
   @JsonCreator
-  public static GroundType fromString(String str) throws GroundDBException {
+  public static GroundType fromString(String str) throws GroundException {
     if (str == null) {
       return null;
     }
@@ -54,7 +54,7 @@ public enum GroundType {
         return LONG;
 
       default: {
-        throw new GroundDBException("Invalid type: " + str + ".");
+        throw new GroundException("Invalid type: " + str + ".");
       }
     }
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/GroundType.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/GroundType.java
@@ -17,7 +17,7 @@ package edu.berkeley.ground.api.versions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public enum GroundType {
   STRING(String.class, "string"),
@@ -38,7 +38,7 @@ public enum GroundType {
   }
 
   @JsonCreator
-  public static GroundType fromString(String str) throws GroundException {
+  public static GroundType fromString(String str) throws GroundDBException {
     if (str == null) {
       return null;
     }
@@ -54,7 +54,7 @@ public enum GroundType {
         return LONG;
 
       default: {
-        throw new GroundException("Invalid type: " + str + ".");
+        throw new GroundDBException("Invalid type: " + str + ".");
       }
     }
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/ItemFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/ItemFactory.java
@@ -15,16 +15,15 @@
 package edu.berkeley.ground.api.versions;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class ItemFactory {
-  public abstract void insertIntoDatabase(GroundDBConnection connection, long id, Map<String, Tag> tags) throws GroundException;
+  public abstract void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundDBException;
 
-  public abstract Item retrieveFromDatabase(GroundDBConnection connection, long id) throws GroundException;
+  public abstract Item retrieveFromDatabase(long id) throws GroundDBException;
 
   /**
    * Add a new Version to this Item. The provided parentIds will be the parents of this particular
@@ -35,7 +34,7 @@ public abstract class ItemFactory {
    * @param childId   the new version's id
    * @param parentIds the ids of the parents of the child
    */
-  public abstract void update(GroundDBConnection connection, long itemId, long childId, List<Long> parentIds) throws GroundException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
 
   public static Item construct(long id, Map<String, Tag> tags) {
     return new Item(id, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/ItemFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/ItemFactory.java
@@ -15,15 +15,15 @@
 package edu.berkeley.ground.api.versions;
 
 import edu.berkeley.ground.api.models.Tag;
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.List;
 import java.util.Map;
 
 public abstract class ItemFactory {
-  public abstract void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundDBException;
+  public abstract void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundException;
 
-  public abstract Item retrieveFromDatabase(long id) throws GroundDBException;
+  public abstract Item retrieveFromDatabase(long id) throws GroundException;
 
   /**
    * Add a new Version to this Item. The provided parentIds will be the parents of this particular
@@ -34,7 +34,7 @@ public abstract class ItemFactory {
    * @param childId   the new version's id
    * @param parentIds the ids of the parents of the child
    */
-  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException;
+  public abstract void update(long itemId, long childId, List<Long> parentIds) throws GroundException;
 
   public static Item construct(long id, Map<String, Tag> tags) {
     return new Item(id, tags);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionFactory.java
@@ -14,9 +14,8 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public abstract class VersionFactory {
-  public abstract void insertIntoDatabase(GroundDBConnection connection, long id) throws GroundException;
+  public abstract void insertIntoDatabase(long id) throws GroundDBException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionFactory.java
@@ -14,8 +14,8 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 public abstract class VersionFactory {
-  public abstract void insertIntoDatabase(long id) throws GroundDBException;
+  public abstract void insertIntoDatabase(long id) throws GroundException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAG.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAG.java
@@ -16,7 +16,7 @@ package edu.berkeley.ground.api.versions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAGFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAGFactory.java
@@ -14,16 +14,15 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class VersionHistoryDAGFactory {
-  public abstract <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundException;
+  public abstract <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundDBException;
 
-  public abstract <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(GroundDBConnection connection, long itemId) throws GroundException;
+  public abstract <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(long itemId) throws GroundDBException;
 
   /**
    * Add a new edge between parentId and childId in DAG
@@ -33,7 +32,7 @@ public abstract class VersionHistoryDAGFactory {
    * @param childId  the child's id
    * @param itemId   the id of the Item whose DAG we're updating
    */
-  public abstract void addEdge(GroundDBConnection connection, VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundException;
+  public abstract void addEdge(VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundDBException;
 
   protected static <T extends Version> VersionHistoryDAG<T> construct(long itemId) {
     return new VersionHistoryDAG<>(itemId, new ArrayList<>());

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAGFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionHistoryDAGFactory.java
@@ -14,15 +14,15 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class VersionHistoryDAGFactory {
-  public abstract <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundDBException;
+  public abstract <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundException;
 
-  public abstract <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(long itemId) throws GroundDBException;
+  public abstract <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(long itemId) throws GroundException;
 
   /**
    * Add a new edge between parentId and childId in DAG
@@ -32,7 +32,7 @@ public abstract class VersionHistoryDAGFactory {
    * @param childId  the child's id
    * @param itemId   the id of the Item whose DAG we're updating
    */
-  public abstract void addEdge(VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundDBException;
+  public abstract void addEdge(VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundException;
 
   protected static <T extends Version> VersionHistoryDAG<T> construct(long itemId) {
     return new VersionHistoryDAG<>(itemId, new ArrayList<>());

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionSuccessorFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionSuccessorFactory.java
@@ -14,12 +14,12 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.exceptions.GroundDBException;
+import edu.berkeley.ground.exceptions.GroundException;
 
 public abstract class VersionSuccessorFactory {
-  public abstract <T extends Version> VersionSuccessor<T> create(long fromId, long toId) throws GroundDBException;
+  public abstract <T extends Version> VersionSuccessor<T> create(long fromId, long toId) throws GroundException;
 
-  public abstract <T extends Version> VersionSuccessor<T> retrieveFromDatabase(long dbId) throws GroundDBException;
+  public abstract <T extends Version> VersionSuccessor<T> retrieveFromDatabase(long dbId) throws GroundException;
 
   protected static <T extends Version> VersionSuccessor<T> construct(long id, long fromId, long toId) {
     return new VersionSuccessor<>(id, fromId, toId);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionSuccessorFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/VersionSuccessorFactory.java
@@ -14,13 +14,12 @@
 
 package edu.berkeley.ground.api.versions;
 
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public abstract class VersionSuccessorFactory {
-  public abstract <T extends Version> VersionSuccessor<T> create(GroundDBConnection connection, long fromId, long toId) throws GroundException;
+  public abstract <T extends Version> VersionSuccessor<T> create(long fromId, long toId) throws GroundDBException;
 
-  public abstract <T extends Version> VersionSuccessor<T> retrieveFromDatabase(GroundDBConnection connection, long dbId) throws GroundException;
+  public abstract <T extends Version> VersionSuccessor<T> retrieveFromDatabase(long dbId) throws GroundDBException;
 
   protected static <T extends Version> VersionSuccessor<T> construct(long id, long fromId, long toId) {
     return new VersionSuccessor<>(id, fromId, toId);

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactory.java
@@ -20,10 +20,9 @@ import edu.berkeley.ground.api.versions.Item;
 import edu.berkeley.ground.api.versions.ItemFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,21 +34,23 @@ import java.util.Map;
 public class CassandraItemFactory extends ItemFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraItemFactory.class);
 
-  private CassandraVersionHistoryDAGFactory versionHistoryDAGFactory;
-  private CassandraTagFactory tagFactory;
+  private final CassandraClient dbClient;
+  private final CassandraVersionHistoryDAGFactory versionHistoryDAGFactory;
+  private final CassandraTagFactory tagFactory;
 
-  public CassandraItemFactory(CassandraVersionHistoryDAGFactory versionHistoryDAGFactory, CassandraTagFactory tagFactory) {
+  public CassandraItemFactory(CassandraClient dbClient,
+                              CassandraVersionHistoryDAGFactory versionHistoryDAGFactory,
+                              CassandraTagFactory tagFactory) {
+    this.dbClient = dbClient;
     this.versionHistoryDAGFactory = versionHistoryDAGFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer, long id, Map<String, Tag> tags) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
+  public void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundDBException {
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("id", GroundType.LONG, id));
 
-    connection.insert("item", insertions);
+    this.dbClient.insert("item", insertions);
 
     for (String key : tags.keySet()) {
       Tag tag = tags.get(key);
@@ -66,16 +67,16 @@ public class CassandraItemFactory extends ItemFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.insert("item_tag", tagInsertion);
+      this.dbClient.insert("item_tag", tagInsertion);
     }
   }
 
-  public Item retrieveFromDatabase(GroundDBConnection connection, long id) throws GroundException {
-    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(connection, id));
+  public Item retrieveFromDatabase(long id) throws GroundDBException {
+    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(id));
   }
 
   // TODO: Refactor logic for parent into function in ItemFactory
-  public void update(GroundDBConnection connectionPointer, long itemId, long childId, List<Long> parentIds) throws GroundException {
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
     // If a parent is specified, great. If it's not specified, then make it a child of EMPTY, which is version 0.
     if (parentIds.isEmpty()) {
       parentIds.add(0L);
@@ -83,8 +84,8 @@ public class CassandraItemFactory extends ItemFactory {
 
     VersionHistoryDAG dag;
     try {
-      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connectionPointer, itemId);
-    } catch (GroundException e) {
+      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No VersionHistoryDAG for Item")) {
         throw e;
       }
@@ -93,23 +94,23 @@ public class CassandraItemFactory extends ItemFactory {
     }
 
     for (long parentId : parentIds) {
-      if (!(parentId == 0) && !dag.checkItemInDag(parentId)) {
+      if (parentId != 0 && !dag.checkItemInDag(parentId)) {
         String errorString = "Parent " + parentId + " is not in Item " + itemId + ".";
 
         LOGGER.error(errorString);
-        throw new GroundException(errorString);
+        throw new GroundDBException(errorString);
       }
 
-      this.versionHistoryDAGFactory.addEdge(connectionPointer, dag, parentId, childId, itemId);
+      this.versionHistoryDAGFactory.addEdge(dag, parentId, childId, itemId);
     }
   }
 
-  public List<Long> getLeaves(GroundDBConnection connection, long itemId) throws GroundException {
+  public List<Long> getLeaves(long itemId) throws GroundDBException {
     try {
-      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connection, itemId);
+      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
 
       return dag.getLeaves();
-    } catch (GroundException e) {
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No results found for query:")) {
         throw e;
       }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionFactory.java
@@ -16,21 +16,24 @@ package edu.berkeley.ground.api.versions.cassandra;
 
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.VersionFactory;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CassandraVersionFactory extends VersionFactory {
-  public void insertIntoDatabase(GroundDBConnection connectionPointer, long id) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
+  private final CassandraClient dbClient;
 
+  public CassandraVersionFactory(CassandraClient dbClient) {
+    this.dbClient = dbClient;
+  }
+
+  public void insertIntoDatabase(long id) throws GroundDBException {
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("id", GroundType.LONG, id));
 
-    connection.insert("version", insertions);
+    this.dbClient.insert("version", insertions);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionHistoryDAGFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionHistoryDAGFactory.java
@@ -15,37 +15,37 @@
 package edu.berkeley.ground.api.versions.cassandra;
 
 import edu.berkeley.ground.api.versions.*;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CassandraVersionHistoryDAGFactory extends VersionHistoryDAGFactory {
-  private CassandraVersionSuccessorFactory versionSuccessorFactory;
+  private final CassandraClient dbClient;
+  private final CassandraVersionSuccessorFactory versionSuccessorFactory;
 
-  public CassandraVersionHistoryDAGFactory(CassandraVersionSuccessorFactory versionSuccessorFactory) {
+  public CassandraVersionHistoryDAGFactory(CassandraClient dbClient,
+                                           CassandraVersionSuccessorFactory versionSuccessorFactory) {
+    this.dbClient = dbClient;
     this.versionSuccessorFactory = versionSuccessorFactory;
   }
 
-  public <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundException {
+  public <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundDBException {
     return construct(itemId);
   }
 
-  public <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(GroundDBConnection connectionPointer, long itemId) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
+  public <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(long itemId) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("item_id", GroundType.LONG, itemId));
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect("version_history_dag", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
+      resultSet = this.dbClient.equalitySelect("version_history_dag", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
       // do nothing' this just means that no versions have been added yet.
       return VersionHistoryDAGFactory.construct(itemId, new ArrayList<VersionSuccessor<T>>());
     }
@@ -53,22 +53,20 @@ public class CassandraVersionHistoryDAGFactory extends VersionHistoryDAGFactory 
     List<VersionSuccessor<T>> edges = new ArrayList<>();
 
     while (resultSet.next()) {
-      edges.add(this.versionSuccessorFactory.retrieveFromDatabase(connection, resultSet.getLong(1)));
+      edges.add(this.versionSuccessorFactory.retrieveFromDatabase(resultSet.getLong(1)));
     }
 
     return VersionHistoryDAGFactory.construct(itemId, edges);
   }
 
-  public void addEdge(GroundDBConnection connectionPointer, VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
-    VersionSuccessor successor = this.versionSuccessorFactory.create(connection, parentId, childId);
+  public void addEdge(VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundDBException {
+    VersionSuccessor successor = this.versionSuccessorFactory.create(parentId, childId);
 
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("item_id", GroundType.LONG, itemId));
     insertions.add(new DbDataContainer("version_successor_id", GroundType.LONG, successor.getId()));
 
-    connection.insert("version_history_dag", insertions);
+    this.dbClient.insert("version_history_dag", insertions);
 
     dag.addEdge(parentId, childId, successor.getId());
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactory.java
@@ -18,52 +18,51 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.Version;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
 import edu.berkeley.ground.api.versions.VersionSuccessorFactory;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
+import edu.berkeley.ground.db.CassandraClient;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
 import edu.berkeley.ground.db.QueryResults;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.util.IdGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CassandraVersionSuccessorFactory extends VersionSuccessorFactory {
-  private IdGenerator idGenerator;
+  private final CassandraClient dbClient;
+  private final IdGenerator idGenerator;
 
-  public CassandraVersionSuccessorFactory(IdGenerator idGenerator) {
+  public CassandraVersionSuccessorFactory(CassandraClient dbClient, IdGenerator idGenerator) {
+    this.dbClient = dbClient;
     this.idGenerator = idGenerator;
   }
 
-  public <T extends Version> VersionSuccessor<T> create(GroundDBConnection connectionPointer, long fromId, long toId) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
+  public <T extends Version> VersionSuccessor<T> create(long fromId, long toId) throws GroundDBException {
     // check to see if both are valid ids since we don't have foreign key constraints
     QueryResults results;
     List<DbDataContainer> predicates = new ArrayList<>();
 
     predicates.add(new DbDataContainer("id", GroundType.LONG, fromId));
     try {
-      results = connection.equalitySelect("version", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("Id " + fromId + " is not valid.");
+      results = this.dbClient.equalitySelect("version", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("Id " + fromId + " is not valid.");
     }
 
     if (!results.next()) {
-      throw new GroundException("Id " + fromId + " is not valid.");
+      throw new GroundDBException("Id " + fromId + " is not valid.");
     }
 
     predicates.clear();
     predicates.add(new DbDataContainer("id", GroundType.LONG, toId));
     try {
-      results = connection.equalitySelect("version", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("Id " + toId + " is not valid.");
+      results = this.dbClient.equalitySelect("version", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("Id " + toId + " is not valid.");
     }
     if (!results.next()) {
-      throw new GroundException("Id " + toId + " is not valid.");
+      throw new GroundDBException("Id " + toId + " is not valid.");
     }
 
     List<DbDataContainer> insertions = new ArrayList<>();
@@ -75,26 +74,24 @@ public class CassandraVersionSuccessorFactory extends VersionSuccessorFactory {
     insertions.add(new DbDataContainer("from_version_id", GroundType.LONG, fromId));
     insertions.add(new DbDataContainer("to_version_id", GroundType.LONG, toId));
 
-    connection.insert("version_successor", insertions);
+    this.dbClient.insert("version_successor", insertions);
 
     return VersionSuccessorFactory.construct(dbId, toId, fromId);
   }
 
-  public <T extends Version> VersionSuccessor<T> retrieveFromDatabase(GroundDBConnection connectionPointer, long dbId) throws GroundException {
-    CassandraConnection connection = (CassandraConnection) connectionPointer;
-
+  public <T extends Version> VersionSuccessor<T> retrieveFromDatabase(long dbId) throws GroundDBException {
     List<DbDataContainer> predicates = new ArrayList<>();
     predicates.add(new DbDataContainer("id", GroundType.LONG, dbId));
 
     QueryResults resultSet;
     try {
-      resultSet = connection.equalitySelect("version_successor", DBClient.SELECT_STAR, predicates);
-    } catch (EmptyResultException eer) {
-      throw new GroundException("No VersionSuccessor found with id " + dbId + ".");
+      resultSet = this.dbClient.equalitySelect("version_successor", DBClient.SELECT_STAR, predicates);
+    } catch (EmptyResultException e) {
+      throw new GroundDBException("No VersionSuccessor found with id " + dbId + ".");
     }
 
     if (!resultSet.next()) {
-      throw new GroundException("No VersionSuccessor found with id " + dbId + ".");
+      throw new GroundDBException("No VersionSuccessor found with id " + dbId + ".");
     }
 
     long fromId = resultSet.getLong("from_version_id");

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/neo4j/Neo4jItemFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/neo4j/Neo4jItemFactory.java
@@ -20,27 +20,28 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.Item;
 import edu.berkeley.ground.api.versions.ItemFactory;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.db.Neo4jClient;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class Neo4jItemFactory extends ItemFactory {
-  private Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory;
-  private Neo4jTagFactory tagFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory;
+  private final Neo4jTagFactory tagFactory;
 
-  public Neo4jItemFactory(Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory, Neo4jTagFactory tagFactory) {
+  public Neo4jItemFactory(Neo4jClient dbClient,
+                          Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory,
+                          Neo4jTagFactory tagFactory) {
+    this.dbClient = dbClient;
     this.versionHistoryDAGFactory = versionHistoryDAGFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer, long id, Map<String, Tag> tags) throws GroundException {
-    Neo4jConnection connection = (Neo4jConnection) connectionPointer;
-
+  public void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundDBException {
     for (String key : tags.keySet()) {
       Tag tag = tags.get(key);
 
@@ -56,26 +57,25 @@ public class Neo4jItemFactory extends ItemFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.addVertexAndEdge("ItemTag", tagInsertion, "ItemTagConnection", id, new ArrayList<>());
+      this.dbClient.addVertexAndEdge("ItemTag", tagInsertion, "ItemTagConnection", id, new ArrayList<>());
       tagInsertion.clear();
     }
   }
 
-  public Item retrieveFromDatabase(GroundDBConnection connection, long id) throws GroundException {
-    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(connection, id));
+  public Item retrieveFromDatabase(long id) throws GroundDBException {
+    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(id));
   }
 
-  public void update(GroundDBConnection connectionPointer, long itemId, long childId, List<Long> parentIds) throws GroundException {
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
     // If a parent is specified, great. If it's not specified, then make it a child of EMPTY.
-
     if (parentIds.isEmpty()) {
       parentIds.add(itemId);
     }
 
     VersionHistoryDAG dag;
     try {
-      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connectionPointer, itemId);
-    } catch (GroundException e) {
+      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No results found for query")) {
         throw e;
       }
@@ -84,22 +84,22 @@ public class Neo4jItemFactory extends ItemFactory {
     }
 
     for (long parentId : parentIds) {
-      if (!(parentId == itemId) && !dag.checkItemInDag(parentId)) {
+      if (parentId != itemId && !dag.checkItemInDag(parentId)) {
         String errorString = "Parent " + parentId + " is not in Item " + itemId + ".";
 
-        throw new GroundException(errorString);
+        throw new GroundDBException(errorString);
       }
 
-      this.versionHistoryDAGFactory.addEdge(connectionPointer, dag, parentId, childId, itemId);
+      this.versionHistoryDAGFactory.addEdge(dag, parentId, childId, itemId);
     }
   }
 
-  public List<Long> getLeaves(GroundDBConnection connection, long itemId) throws GroundException {
+  public List<Long> getLeaves(long itemId) throws GroundDBException {
     try {
-      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connection, itemId);
+      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
 
       return dag.getLeaves();
-    } catch (GroundException e) {
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No results found for query")) {
         throw e;
       }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionHistoryDAGFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionHistoryDAGFactory.java
@@ -18,10 +18,8 @@ import edu.berkeley.ground.api.versions.Version;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
 import edu.berkeley.ground.api.versions.VersionHistoryDAGFactory;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.Neo4jClient;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.v1.types.Relationship;
@@ -30,19 +28,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Neo4jVersionHistoryDAGFactory extends VersionHistoryDAGFactory {
-  private Neo4jVersionSuccessorFactory versionSuccessorFactory;
+  private final Neo4jClient dbClient;
+  private final Neo4jVersionSuccessorFactory versionSuccessorFactory;
 
-  public Neo4jVersionHistoryDAGFactory(Neo4jVersionSuccessorFactory versionSuccessorFactory) {
+  public Neo4jVersionHistoryDAGFactory(Neo4jClient dbClient,
+                                       Neo4jVersionSuccessorFactory versionSuccessorFactory) {
+    this.dbClient = dbClient;
     this.versionSuccessorFactory = versionSuccessorFactory;
   }
 
-  public <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundException {
+  public <T extends Version> VersionHistoryDAG<T> create(long itemId) throws GroundDBException {
     return construct(itemId);
   }
 
-  public <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(GroundDBConnection connectionPointer, long itemId) throws GroundException {
-    Neo4jConnection connection = (Neo4jConnection) connectionPointer;
-    List<Relationship> result = connection.getDescendantEdgesByLabel(itemId, "VersionSuccessor");
+  public <T extends Version> VersionHistoryDAG<T> retrieveFromDatabase(long itemId) throws GroundDBException {
+    List<Relationship> result = this.dbClient.getDescendantEdgesByLabel(itemId, "VersionSuccessor");
 
     if (result.isEmpty()) {
       // do nothing' this just means that no versions have been added yet.
@@ -52,14 +52,14 @@ public class Neo4jVersionHistoryDAGFactory extends VersionHistoryDAGFactory {
     List<VersionSuccessor<T>> edges = new ArrayList<>();
 
     for (Relationship relationship : result) {
-      edges.add(this.versionSuccessorFactory.retrieveFromDatabase(connection, relationship.get("id").asLong()));
+      edges.add(this.versionSuccessorFactory.retrieveFromDatabase(relationship.get("id").asLong()));
     }
 
     return construct(itemId, edges);
   }
 
-  public void addEdge(GroundDBConnection connection, VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundException {
-    VersionSuccessor successor = this.versionSuccessorFactory.create(connection, parentId, childId);
+  public void addEdge(VersionHistoryDAG dag, long parentId, long childId, long itemId) throws GroundDBException {
+    VersionSuccessor successor = this.versionSuccessorFactory.create(parentId, childId);
 
     dag.addEdge(parentId, childId, successor.getId());
   }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/postgres/PostgresItemFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/postgres/PostgresItemFactory.java
@@ -20,10 +20,9 @@ import edu.berkeley.ground.api.versions.Item;
 import edu.berkeley.ground.api.versions.ItemFactory;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.db.PostgresClient;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,21 +34,21 @@ import java.util.Map;
 public class PostgresItemFactory extends ItemFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresItemFactory.class);
 
-  private PostgresVersionHistoryDAGFactory versionHistoryDAGFactory;
-  private PostgresTagFactory tagFactory;
+  private final PostgresClient dbClient;
+  private final PostgresVersionHistoryDAGFactory versionHistoryDAGFactory;
+  private final PostgresTagFactory tagFactory;
 
-  public PostgresItemFactory(PostgresVersionHistoryDAGFactory versionHistoryDAGFactory, PostgresTagFactory tagFactory) {
+  public PostgresItemFactory(PostgresClient dbClient, PostgresVersionHistoryDAGFactory versionHistoryDAGFactory, PostgresTagFactory tagFactory) {
+    this.dbClient = dbClient;
     this.versionHistoryDAGFactory = versionHistoryDAGFactory;
     this.tagFactory = tagFactory;
   }
 
-  public void insertIntoDatabase(GroundDBConnection connectionPointer, long id, Map<String, Tag> tags) throws GroundException {
-    PostgresConnection connection = (PostgresConnection) connectionPointer;
-
+  public void insertIntoDatabase(long id, Map<String, Tag> tags) throws GroundDBException {
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("id", GroundType.LONG, id));
 
-    connection.insert("item", insertions);
+    this.dbClient.insert("item", insertions);
 
     for (String key : tags.keySet()) {
       Tag tag = tags.get(key);
@@ -66,16 +65,16 @@ public class PostgresItemFactory extends ItemFactory {
         tagInsertion.add(new DbDataContainer("type", GroundType.STRING, null));
       }
 
-      connection.insert("item_tag", tagInsertion);
+      this.dbClient.insert("item_tag", tagInsertion);
     }
   }
 
-  public Item retrieveFromDatabase(GroundDBConnection connection, long id) throws GroundException {
-    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(connection, id));
+  public Item retrieveFromDatabase(long id) throws GroundDBException {
+    return ItemFactory.construct(id, this.tagFactory.retrieveFromDatabaseByItemId(id));
   }
 
 
-  public void update(GroundDBConnection connectionPointer, long itemId, long childId, List<Long> parentIds) throws GroundException {
+  public void update(long itemId, long childId, List<Long> parentIds) throws GroundDBException {
     // If a parent is specified, great. If it's not specified, then make it a child of EMPTY.
     if (parentIds.isEmpty()) {
       parentIds.add(0L);
@@ -83,8 +82,8 @@ public class PostgresItemFactory extends ItemFactory {
 
     VersionHistoryDAG dag;
     try {
-      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connectionPointer, itemId);
-    } catch (GroundException e) {
+      dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No results found for query:")) {
         throw e;
       }
@@ -93,23 +92,23 @@ public class PostgresItemFactory extends ItemFactory {
     }
 
     for (long parentId : parentIds) {
-      if (!(parentId == 0) && !dag.checkItemInDag(parentId)) {
+      if (parentId != 0 && !dag.checkItemInDag(parentId)) {
         String errorString = "Parent " + parentId + " is not in Item " + itemId + ".";
 
         LOGGER.error(errorString);
-        throw new GroundException(errorString);
+        throw new GroundDBException(errorString);
       }
 
-      this.versionHistoryDAGFactory.addEdge(connectionPointer, dag, parentId, childId, itemId);
+      this.versionHistoryDAGFactory.addEdge(dag, parentId, childId, itemId);
     }
   }
 
-  public List<Long> getLeaves(GroundDBConnection connection, long itemId) throws GroundException {
+  public List<Long> getLeaves(long itemId) throws GroundDBException {
     try {
-      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(connection, itemId);
+      VersionHistoryDAG<?> dag = this.versionHistoryDAGFactory.retrieveFromDatabase(itemId);
 
       return dag.getLeaves();
-    } catch (GroundException e) {
+    } catch (GroundDBException e) {
       if (!e.getMessage().contains("No results found for query:")) {
         throw e;
       }

--- a/ground-core/src/main/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionFactory.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionFactory.java
@@ -16,21 +16,24 @@ package edu.berkeley.ground.api.versions.postgres;
 
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.VersionFactory;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.DbDataContainer;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.db.PostgresClient;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PostgresVersionFactory extends VersionFactory {
-  public void insertIntoDatabase(GroundDBConnection connectionPointer, long id) throws GroundException {
-    PostgresConnection connection = (PostgresConnection) connectionPointer;
+  private final PostgresClient dbClient;
 
+  public PostgresVersionFactory(PostgresClient dbClient) {
+    this.dbClient = dbClient;
+  }
+
+  public void insertIntoDatabase(long id) throws GroundDBException {
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("id", GroundType.LONG, id));
 
-    connection.insert("version", insertions);
+    this.dbClient.insert("version", insertions);
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class CassandraClient implements DBClient, AutoCloseable {
+public class CassandraClient extends DBClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraClient.class);
 
   private final Cluster cluster;

--- a/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/CassandraClient.java
@@ -36,7 +36,6 @@ public class CassandraClient implements DBClient, AutoCloseable {
         Cluster.builder()
             .addContactPoint(host)
             .withAuthProvider(new PlainTextAuthProvider(username, password))
-            .withPort(port)
             .build();
 
     this.session = this.cluster.connect(keyspace);

--- a/ground-core/src/main/java/edu/berkeley/ground/db/CassandraResults.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/CassandraResults.java
@@ -17,11 +17,7 @@ package edu.berkeley.ground.db;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 
-import edu.berkeley.ground.exceptions.GroundException;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public class CassandraResults implements QueryResults {
   private ResultSet resultSet;
@@ -32,55 +28,55 @@ public class CassandraResults implements QueryResults {
     this.currentRow = null;
   }
 
-  public String getString(int index) throws GroundException {
+  public String getString(int index) throws GroundDBException {
     try {
       return this.currentRow.getString(index);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public String getString(String field) throws GroundException {
+  public String getString(String field) throws GroundDBException {
     try {
       return this.currentRow.getString(field);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public int getInt(int index) throws GroundException {
+  public int getInt(int index) throws GroundDBException {
     try {
       return this.currentRow.getInt(index);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public boolean getBoolean(int index) throws GroundException {
+  public boolean getBoolean(int index) throws GroundDBException {
     try {
       return this.currentRow.getBool(index);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public long getLong(int index) throws GroundException {
+  public long getLong(int index) throws GroundDBException {
     try {
       return this.currentRow.getLong(index);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public long getLong(String field) throws GroundException {
+  public long getLong(String field) throws GroundDBException {
     try {
       return this.currentRow.getLong(field);
     } catch (Exception e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public boolean next() throws GroundException {
+  public boolean next() {
     this.currentRow = this.resultSet.one();
 
     return this.currentRow != null;

--- a/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
@@ -1,21 +1,17 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package edu.berkeley.ground.db;
 
 import edu.berkeley.ground.exceptions.GroundDBException;
-import edu.berkeley.ground.exceptions.GroundException;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,19 +19,15 @@ import java.util.List;
 public interface DBClient {
   List<String> SELECT_STAR = Collections.singletonList("*");
 
-  GroundDBConnection getConnection() throws GroundDBException;
+  void commit() throws GroundDBException;
 
-  abstract class GroundDBConnection implements AutoCloseable {
-    public abstract void commit() throws GroundDBException;
+  void abort() throws GroundDBException;
 
-    public abstract void abort() throws GroundDBException;
-
-    /**
-     * Run transitive closure from nodeVersionId.
-     *
-     * @param nodeVersionId the start id
-     * @return the list of reachable ids
-     */
-    public abstract List<Long> transitiveClosure(long nodeVersionId) throws GroundException;
-  }
+  /**
+   * Run transitive closure from nodeVersionId.
+   *
+   * @param nodeVersionId the start id
+   * @return the list of reachable ids
+   */
+  List<Long> transitiveClosure(long nodeVersionId) throws GroundDBException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
@@ -16,12 +16,12 @@ import edu.berkeley.ground.exceptions.GroundDBException;
 import java.util.Collections;
 import java.util.List;
 
-public interface DBClient {
-  List<String> SELECT_STAR = Collections.singletonList("*");
+public abstract class DBClient implements AutoCloseable {
+  public static final List<String> SELECT_STAR = Collections.singletonList("*");
 
-  void commit() throws GroundDBException;
+  public abstract void commit() throws GroundDBException;
 
-  void abort() throws GroundDBException;
+  public abstract void abort() throws GroundDBException;
 
   /**
    * Run transitive closure from nodeVersionId.
@@ -29,5 +29,5 @@ public interface DBClient {
    * @param nodeVersionId the start id
    * @return the list of reachable ids
    */
-  List<Long> transitiveClosure(long nodeVersionId) throws GroundDBException;
+  public abstract List<Long> transitiveClosure(long nodeVersionId) throws GroundDBException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/DBClient.java
@@ -25,7 +25,7 @@ public interface DBClient {
 
   GroundDBConnection getConnection() throws GroundDBException;
 
-  abstract class GroundDBConnection {
+  abstract class GroundDBConnection implements AutoCloseable {
     public abstract void commit() throws GroundDBException;
 
     public abstract void abort() throws GroundDBException;

--- a/ground-core/src/main/java/edu/berkeley/ground/db/DbDataContainer.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/DbDataContainer.java
@@ -15,7 +15,7 @@
 package edu.berkeley.ground.db;
 
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public class DbDataContainer {
   // the name of the field
@@ -27,9 +27,9 @@ public class DbDataContainer {
   // the value of the field;
   private Object value;
 
-  public DbDataContainer(String field, GroundType groundType, Object value) throws GroundException {
+  public DbDataContainer(String field, GroundType groundType, Object value) throws GroundDBException {
     if (value != null && !(value.getClass().equals(groundType.getTypeClass()))) {
-      throw new GroundException("Value of type " + value.getClass().toString() + " does not correspond to type of " + groundType.getTypeClass().toString() + ".");
+      throw new GroundDBException("Value of type " + value.getClass().toString() + " does not correspond to type of " + groundType.getTypeClass().toString() + ".");
     }
 
     this.field = field;

--- a/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
@@ -17,7 +17,6 @@ package edu.berkeley.ground.db;
 import com.google.common.annotations.VisibleForTesting;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.exceptions.EmptyResultException;
-import edu.berkeley.ground.exceptions.GroundException;
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.v1.*;
 import org.neo4j.driver.v1.types.Relationship;
@@ -30,357 +29,340 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Neo4jClient implements DBClient {
+public class Neo4jClient implements DBClient, AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jClient.class);
 
   private final Driver driver;
+  private final Session session;
+  private final Transaction transaction;
 
   public Neo4jClient(String host, String username, String password) {
     this.driver = GraphDatabase.driver("bolt://" + host, AuthTokens.basic(username, password));
+    this.session = this.driver.session();
+    this.transaction = session.beginTransaction();
   }
 
-  public Neo4jConnection getConnection() {
-    return new Neo4jConnection(this.driver.session());
-  }
+  private String addValuesToStatement(String statement, List<DbDataContainer> values) {
+    int count = 0;
+    for (DbDataContainer container : values) {
+      if (container.getValue() != null) {
+        statement += container.getField() + " : ";
 
-  public class Neo4jConnection extends GroundDBConnection {
-    private final Transaction transaction;
-    private final Session session;
-
-    public Neo4jConnection(Session session) {
-      this.transaction = session.beginTransaction();
-      this.session = session;
-    }
-
-    private String addValuesToStatement(String statement, List<DbDataContainer> values) {
-      int count = 0;
-      for (DbDataContainer container : values) {
-        if (container.getValue() != null) {
-          statement += container.getField() + " : ";
-
-          switch (container.getGroundType()) {
-            case STRING:
-              statement += "'" + container.getValue().toString() + "'";
-              break;
-            case INTEGER:
-              statement += (int) container.getValue();
-              break;
-            case BOOLEAN:
-              statement += container.getValue();
-              break;
-            case LONG:
-              statement += (long) container.getValue();
-              break;
-          }
-
-          statement += ", ";
-          count++;
+        switch (container.getGroundType()) {
+          case STRING:
+            statement += "'" + container.getValue().toString() + "'";
+            break;
+          case INTEGER:
+            statement += (int) container.getValue();
+            break;
+          case BOOLEAN:
+            statement += container.getValue();
+            break;
+          case LONG:
+            statement += (long) container.getValue();
+            break;
         }
+
+        statement += ", ";
+        count++;
       }
-
-      if (count > 0) {
-        statement = statement.substring(0, statement.length() - 2);
-      }
-
-      return statement;
     }
 
-    /**
-     * Add a new vertex to the graph.
-     *
-     * @param label the vertex label
-     * @param attributes the vertex's attributes
-     */
-    public void addVertex(String label, List<DbDataContainer> attributes) {
-      String insert = "CREATE (: " + label + " {";
-
-      insert = this.addValuesToStatement(insert, attributes);
-      insert += "})";
-
-      this.transaction.run(insert);
+    if (count > 0) {
+      statement = statement.substring(0, statement.length() - 2);
     }
 
-    /**
-     * Add a new edge to the graph.
-     *
-     * @param label the edge label
-     * @param fromId the id of the source vertex
-     * @param toId the id of the destination vertex
-     * @param attributes the edge's attributes
-     */
-    public void addEdge(String label, long fromId, long toId, List<DbDataContainer> attributes) {
-      String insert =
-          "MATCH (f"
-              + "{id : "
-              + fromId
-              + " })"
-              + "MATCH (t"
-              + "{id : "
-              + toId
-              + " })"
-              + "CREATE (f)-[:"
-              + label
-              + "{";
+    return statement;
+  }
 
-      insert = this.addValuesToStatement(insert, attributes);
-      insert += "}]->(t)";
+  /**
+   * Add a new vertex to the graph.
+   *
+   * @param label the vertex label
+   * @param attributes the vertex's attributes
+   */
+  public void addVertex(String label, List<DbDataContainer> attributes) {
+    String insert = "CREATE (: " + label + " {";
 
-      this.transaction.run(insert);
+    insert = this.addValuesToStatement(insert, attributes);
+    insert += "})";
+
+    this.transaction.run(insert);
+  }
+
+  /**
+   * Add a new edge to the graph.
+   *
+   * @param label the edge label
+   * @param fromId the id of the source vertex
+   * @param toId the id of the destination vertex
+   * @param attributes the edge's attributes
+   */
+  public void addEdge(String label, long fromId, long toId, List<DbDataContainer> attributes) {
+    String insert =
+        "MATCH (f"
+            + "{id : "
+            + fromId
+            + " })"
+            + "MATCH (t"
+            + "{id : "
+            + toId
+            + " })"
+            + "CREATE (f)-[:"
+            + label
+            + "{";
+
+    insert = this.addValuesToStatement(insert, attributes);
+    insert += "}]->(t)";
+
+    this.transaction.run(insert);
+  }
+
+  /**
+   * Add a new edge to the graph.
+   *
+   * @param label the edge label
+   * @param fromId the id of the source vertex
+   * @param toId the id of the destination vertex
+   * @param attributes the edge's attributes
+   */
+  public void addEdge(String label, String fromId, long toId, List<DbDataContainer> attributes) {
+    String insert = "MATCH (f" + "{id : '" + fromId + "' })";
+    insert += "MATCH (t" + "{id : " + toId + " })";
+    insert += "CREATE (f)-[:" + label + "{";
+
+    insert = this.addValuesToStatement(insert, attributes);
+    insert += "}]->(t)";
+
+    this.transaction.run(insert);
+  }
+
+  /**
+   * Add a new vertex and an edge connecting it to another vertex
+   *
+   * @param label the vertex label
+   * @param attributes the vertex's attributes
+   * @param edgeLabel the edge label
+   * @param fromId the source of the edge
+   * @param edgeAttributes the edge's attributes
+   */
+  public void addVertexAndEdge(
+      String label,
+      List<DbDataContainer> attributes,
+      String edgeLabel,
+      long fromId,
+      List<DbDataContainer> edgeAttributes) {
+    String insert = "MATCH (f {id: " + fromId + "})";
+    insert += "CREATE (t: " + label + "{";
+
+    insert = this.addValuesToStatement(insert, attributes);
+    insert += "})";
+    insert += "CREATE (f)-[e: " + edgeLabel + "{";
+
+    insert = this.addValuesToStatement(insert, edgeAttributes);
+    insert += "}]->(t)";
+
+    this.transaction.run(insert);
+  }
+
+  /**
+   * Retrieve a vertex.
+   *
+   * @param attributes the set of attributes to filter
+   * @return the Record of the vertex
+   */
+  public Record getVertex(List<DbDataContainer> attributes) throws EmptyResultException {
+    return this.getVertex(null, attributes);
+  }
+
+  /**
+   * Get all vertices with a certain set of attributes.
+   *
+   * @param attributes the attributes to filter by
+   */
+  public List<Long> getVerticesByAttributes(List<DbDataContainer> attributes, String idAttribute) {
+    String query = "MATCH (f {";
+
+    query = this.addValuesToStatement(query, attributes);
+    query += "}) where exists(f." + idAttribute + ") return f";
+
+    StatementResult queryResult = this.transaction.run(query);
+
+    List<Long> result = new ArrayList<>();
+    while (queryResult.hasNext()) {
+      result.add(
+          (Long)
+              GroundType.stringToType(
+                  queryResult.next().get("f").asNode().get(idAttribute).toString(),
+                  GroundType.LONG));
     }
 
-    /**
-     * Add a new edge to the graph.
-     *
-     * @param label the edge label
-     * @param fromId the id of the source vertex
-     * @param toId the id of the destination vertex
-     * @param attributes the edge's attributes
-     */
-    public void addEdge(String label, String fromId, long toId, List<DbDataContainer> attributes) {
-      String insert = "MATCH (f" + "{id : '" + fromId + "' })";
-      insert += "MATCH (t" + "{id : " + toId + " })";
-      insert += "CREATE (f)-[:" + label + "{";
+    return result;
+  }
 
-      insert = this.addValuesToStatement(insert, attributes);
-      insert += "}]->(t)";
-
-      this.transaction.run(insert);
+  /**
+   * Get a vertex with a set of attributes and with a particular label.
+   *
+   * @param label the vertex label
+   * @param attributes the attributes to filter by
+   * @return the Record with the vertex
+   */
+  public Record getVertex(String label, List<DbDataContainer> attributes)
+      throws EmptyResultException {
+    String query = "MATCH (v";
+    if (label == null) {
+      query += " {";
+    } else {
+      query += ":" + label + "{";
     }
 
-    /**
-     * Add a new vertex and an edge connecting it to another vertex
-     *
-     * @param label the vertex label
-     * @param attributes the vertex's attributes
-     * @param edgeLabel the edge label
-     * @param fromId the source of the edge
-     * @param edgeAttributes the edge's attributes
-     */
-    public void addVertexAndEdge(
-        String label,
-        List<DbDataContainer> attributes,
-        String edgeLabel,
-        long fromId,
-        List<DbDataContainer> edgeAttributes) {
-      String insert = "MATCH (f {id: " + fromId + "})";
-      insert += "CREATE (t: " + label + "{";
+    query = this.addValuesToStatement(query, attributes);
+    query += "}) RETURN v";
+    StatementResult result = this.transaction.run(query);
 
-      insert = this.addValuesToStatement(insert, attributes);
-      insert += "})";
-      insert += "CREATE (f)-[e: " + edgeLabel + "{";
-
-      insert = this.addValuesToStatement(insert, edgeAttributes);
-      insert += "}]->(t)";
-
-      this.transaction.run(insert);
+    if (result.hasNext()) {
+      return result.next();
     }
 
-    /**
-     * Retrieve a vertex.
-     *
-     * @param attributes the set of attributes to filter
-     * @return the Record of the vertex
-     */
-    public Record getVertex(List<DbDataContainer> attributes) throws EmptyResultException {
-      return this.getVertex(null, attributes);
+    throw new EmptyResultException("No results found for query: " + query);
+  }
+
+  /**
+   * Retrieve an edge.
+   *
+   * @param label the edge label
+   * @param attributes the attributes to filter by
+   * @return the Neo4j Relationship for this edge
+   */
+  public Relationship getEdge(String label, List<DbDataContainer> attributes)
+      throws EmptyResultException {
+    String query = "MATCH (v)-[e:" + label + "{";
+
+    query = this.addValuesToStatement(query, attributes);
+    query += "}]->(w) RETURN e";
+
+    StatementResult result = this.transaction.run(query);
+
+    if (result.hasNext()) {
+      Record r = result.next();
+      return r.get("e").asRelationship();
     }
 
-    /**
-     * Get all vertices with a certain set of attributes.
-     *
-     * @param attributes the attributes to filter by
-     */
-    public List<Long> getVerticesByAttributes(
-        List<DbDataContainer> attributes, String idAttribute) {
-      String query = "MATCH (f {";
+    throw new EmptyResultException("No results found for query: " + query);
+  }
 
-      query = this.addValuesToStatement(query, attributes);
-      query += "}) where exists(f." + idAttribute + ") return f";
+  /**
+   * Get all the edges with a particular label that are reachable from a particular starting vertex.
+   *
+   * @param startId the starting point for the query
+   * @param label the edge label we are looking for
+   * @return the list of valid edges
+   */
+  public List<Relationship> getDescendantEdgesByLabel(long startId, String label) {
+    String query = "MATCH (a {id: " + startId + "})-[e: " + label + "*]->(b) return distinct e;";
+    StatementResult result = this.transaction.run(query);
 
-      StatementResult queryResult = this.transaction.run(query);
+    Set<Relationship> response = new HashSet<>();
 
-      List<Long> result = new ArrayList<>();
-      while (queryResult.hasNext()) {
-        result.add(
-            (Long)
-                GroundType.stringToType(
-                    queryResult.next().get("f").asNode().get(idAttribute).toString(),
-                    GroundType.LONG));
-      }
-
-      return result;
+    while (result.hasNext()) {
+      List<Object> list = result.next().get("e").asList();
+      list.forEach(s -> response.add((Relationship) s));
     }
 
-    /**
-     * Get a vertex with a set of attributes and with a particular label.
-     *
-     * @param label the vertex label
-     * @param attributes the attributes to filter by
-     * @return the Record with the vertex
-     */
-    public Record getVertex(String label, List<DbDataContainer> attributes)
-        throws EmptyResultException {
-      String query = "MATCH (v";
-      if (label == null) {
-        query += " {";
-      } else {
-        query += ":" + label + "{";
-      }
+    return new ArrayList<>(response);
+  }
 
-      query = this.addValuesToStatement(query, attributes);
-      query += "}) RETURN v";
-      StatementResult result = this.transaction.run(query);
+  /**
+   * Get all vertices that are one edge away, where the edge connecting them has a particular label.
+   *
+   * @param id the vertex to start from
+   * @param edgeLabel the edge label we are looking for
+   * @param returnFields the list of fields we want to select
+   * @return a list of adjacent vertices related by edgeLabel
+   */
+  public List<Record> getAdjacentVerticesByEdgeLabel(
+      String edgeLabel, long id, List<String> returnFields) {
+    String query =
+        "MATCH (a {id: " + id + " })" + "MATCH (a)-[:" + edgeLabel + "]->(b)" + "RETURN ";
 
-      if (result.hasNext()) {
-        return result.next();
-      }
+    query +=
+        returnFields
+            .stream()
+            .map(field -> "b." + field + " as " + field)
+            .collect(Collectors.joining(", "));
 
-      throw new EmptyResultException("No results found for query: " + query);
+    StatementResult result = this.transaction.run(query);
+    return result.list();
+  }
+
+  @Override
+  public List<Long> transitiveClosure(long nodeVersionId) {
+    String query =
+        "MATCH (a: NodeVersion {id: "
+            + nodeVersionId
+            + "})-"
+            + "[:EdgeVersionConnection*]->(b: NodeVersion) RETURN b.id";
+
+    List<Record> records = this.transaction.run(query).list();
+    List<Long> result =
+        records.stream().map(record -> record.get("b.id").asLong()).collect(Collectors.toList());
+
+    return result;
+  }
+
+  /**
+   * For a particular object, set a given attribute.
+   *
+   * @param id the id of the object
+   * @param key the key of the attribute
+   * @param value the value of the attribute
+   * @param isString determines whether or not to encapsulate value in quotes
+   */
+  public void setProperty(long id, String key, Object value, boolean isString) {
+    String insert = "MATCH (n {id: " + id + " })" + "set n." + key + " = ";
+
+    if (isString) {
+      insert += "'" + value.toString() + "'";
+    } else {
+      insert += value.toString();
     }
 
-    /**
-     * Retrieve an edge.
-     *
-     * @param label the edge label
-     * @param attributes the attributes to filter by
-     * @return the Neo4j Relationship for this edge
-     */
-    public Relationship getEdge(String label, List<DbDataContainer> attributes)
-        throws EmptyResultException {
-      String query = "MATCH (v)-[e:" + label + "{";
+    this.transaction.run(insert);
+  }
 
-      query = this.addValuesToStatement(query, attributes);
-      query += "}]->(w) RETURN e";
+  public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex) {
+    String query =
+        "MATCH (n: NodeVersion {id: '"
+            + nodeVersionId
+            + "'})"
+            + "-[e: EdgeVersionConnection]->(evn: EdgeVersion) where evn.edge_id =~ '.*"
+            + edgeNameRegex
+            + ".*'"
+            + "MATCH (evn)-[f: EdgeVersionConnection]->(dst)"
+            + "return dst.id";
 
-      StatementResult result = this.transaction.run(query);
+    List<Record> records = this.transaction.run(query).list();
+    List<Long> result =
+        records.stream().map(record -> record.get("dst.id").asLong()).collect(Collectors.toList());
 
-      if (result.hasNext()) {
-        Record r = result.next();
-        return r.get("e").asRelationship();
-      }
+    return result;
+  }
 
-      throw new EmptyResultException("No results found for query: " + query);
-    }
+  @Override
+  public void commit() {
+    this.transaction.success();
+  }
 
-    /**
-     * Get all the edges with a particular label that are reachable from a particular starting
-     * vertex.
-     *
-     * @param startId the starting point for the query
-     * @param label the edge label we are looking for
-     * @return the list of valid edges
-     */
-    public List<Relationship> getDescendantEdgesByLabel(long startId, String label) {
-      String query = "MATCH (a {id: " + startId + "})-[e: " + label + "*]->(b) return distinct e;";
-      StatementResult result = this.transaction.run(query);
+  @Override
+  public void abort() {
+    this.transaction.failure();
+  }
 
-      Set<Relationship> response = new HashSet<>();
-
-      while (result.hasNext()) {
-        List<Object> list = result.next().get("e").asList();
-        list.forEach(s -> response.add((Relationship) s));
-      }
-
-      return new ArrayList<>(response);
-    }
-
-    /**
-     * Get all vertices that are one edge away, where the edge connecting them has a particular
-     * label.
-     *
-     * @param id the vertex to start from
-     * @param edgeLabel the edge label we are looking for
-     * @param returnFields the list of fields we want to select
-     * @return a list of adjacent vertices related by edgeLabel
-     */
-    public List<Record> getAdjacentVerticesByEdgeLabel(
-        String edgeLabel, long id, List<String> returnFields) {
-      String query =
-          "MATCH (a {id: " + id + " })" + "MATCH (a)-[:" + edgeLabel + "]->(b)" + "RETURN ";
-
-      query +=
-          returnFields
-              .stream()
-              .map(field -> "b." + field + " as " + field)
-              .collect(Collectors.joining(", "));
-
-      StatementResult result = this.transaction.run(query);
-      return result.list();
-    }
-
-    public List<Long> transitiveClosure(long nodeVersionId) throws GroundException {
-      String query =
-          "MATCH (a: NodeVersion {id: "
-              + nodeVersionId
-              + "})-"
-              + "[:EdgeVersionConnection*]->(b: NodeVersion) RETURN b.id";
-
-      List<Record> records = this.transaction.run(query).list();
-      List<Long> result =
-          records.stream().map(record -> record.get("b.id").asLong()).collect(Collectors.toList());
-
-      return result;
-    }
-
-    /**
-     * For a particular object, set a given attribute.
-     *
-     * @param id the id of the object
-     * @param key the key of the attribute
-     * @param value the value of the attribute
-     * @param isString determines whether or not to encapsulate value in quotes
-     */
-    public void setProperty(long id, String key, Object value, boolean isString) {
-      String insert = "MATCH (n {id: " + id + " })" + "set n." + key + " = ";
-
-      if (isString) {
-        insert += "'" + value.toString() + "'";
-      } else {
-        insert += value.toString();
-      }
-
-      this.transaction.run(insert);
-    }
-
-    public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex)
-        throws GroundException {
-      String query =
-          "MATCH (n: NodeVersion {id: '"
-              + nodeVersionId
-              + "'})"
-              + "-[e: EdgeVersionConnection]->(evn: EdgeVersion) where evn.edge_id =~ '.*"
-              + edgeNameRegex
-              + ".*'"
-              + "MATCH (evn)-[f: EdgeVersionConnection]->(dst)"
-              + "return dst.id";
-
-      List<Record> records = this.transaction.run(query).list();
-      List<Long> result =
-          records
-              .stream()
-              .map(record -> record.get("dst.id").asLong())
-              .collect(Collectors.toList());
-
-      return result;
-    }
-
-    @Override
-    public void commit() {
-      this.transaction.success();
-      this.close();
-    }
-
-    @Override
-    public void abort() {
-      this.transaction.failure();
-      this.close();
-    }
-
-    @Override
-    public void close() {
-      this.transaction.close();
-      this.session.close();
-    }
+  @Override
+  public void close() {
+    this.transaction.close();
+    this.session.close();
+    this.driver.close();
   }
 
   public static String getStringFromValue(StringValue value) {

--- a/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
@@ -15,12 +15,10 @@
 package edu.berkeley.ground.db;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.exceptions.EmptyResultException;
 import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.exceptions.GroundException;
-
 import org.neo4j.driver.internal.value.StringValue;
 import org.neo4j.driver.v1.*;
 import org.neo4j.driver.v1.types.Relationship;
@@ -32,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class Neo4jClient implements DBClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jClient.class);
@@ -92,7 +89,7 @@ public class Neo4jClient implements DBClient {
     /**
      * Add a new vertex to the graph.
      *
-     * @param label      the vertex label
+     * @param label the vertex label
      * @param attributes the vertex's attributes
      */
     public void addVertex(String label, List<DbDataContainer> attributes) {
@@ -107,15 +104,24 @@ public class Neo4jClient implements DBClient {
     /**
      * Add a new edge to the graph.
      *
-     * @param label      the edge label
-     * @param fromId     the id of the source vertex
-     * @param toId       the id of the destination vertex
+     * @param label the edge label
+     * @param fromId the id of the source vertex
+     * @param toId the id of the destination vertex
      * @param attributes the edge's attributes
      */
     public void addEdge(String label, long fromId, long toId, List<DbDataContainer> attributes) {
-      String insert = "MATCH (f" + "{id : " + fromId + " })" +
-          "MATCH (t" + "{id : " + toId + " })" +
-          "CREATE (f)-[:" + label + "{";
+      String insert =
+          "MATCH (f"
+              + "{id : "
+              + fromId
+              + " })"
+              + "MATCH (t"
+              + "{id : "
+              + toId
+              + " })"
+              + "CREATE (f)-[:"
+              + label
+              + "{";
 
       insert = this.addValuesToStatement(insert, attributes);
       insert += "}]->(t)";
@@ -126,9 +132,9 @@ public class Neo4jClient implements DBClient {
     /**
      * Add a new edge to the graph.
      *
-     * @param label      the edge label
-     * @param fromId     the id of the source vertex
-     * @param toId       the id of the destination vertex
+     * @param label the edge label
+     * @param fromId the id of the source vertex
+     * @param toId the id of the destination vertex
      * @param attributes the edge's attributes
      */
     public void addEdge(String label, String fromId, long toId, List<DbDataContainer> attributes) {
@@ -145,13 +151,18 @@ public class Neo4jClient implements DBClient {
     /**
      * Add a new vertex and an edge connecting it to another vertex
      *
-     * @param label          the vertex label
-     * @param attributes     the vertex's attributes
-     * @param edgeLabel      the edge label
-     * @param fromId         the source of the edge
+     * @param label the vertex label
+     * @param attributes the vertex's attributes
+     * @param edgeLabel the edge label
+     * @param fromId the source of the edge
      * @param edgeAttributes the edge's attributes
      */
-    public void addVertexAndEdge(String label, List<DbDataContainer> attributes, String edgeLabel, long fromId, List<DbDataContainer> edgeAttributes) {
+    public void addVertexAndEdge(
+        String label,
+        List<DbDataContainer> attributes,
+        String edgeLabel,
+        long fromId,
+        List<DbDataContainer> edgeAttributes) {
       String insert = "MATCH (f {id: " + fromId + "})";
       insert += "CREATE (t: " + label + "{";
 
@@ -180,7 +191,8 @@ public class Neo4jClient implements DBClient {
      *
      * @param attributes the attributes to filter by
      */
-    public List<Long> getVerticesByAttributes(List<DbDataContainer> attributes, String idAttribute) {
+    public List<Long> getVerticesByAttributes(
+        List<DbDataContainer> attributes, String idAttribute) {
       String query = "MATCH (f {";
 
       query = this.addValuesToStatement(query, attributes);
@@ -190,8 +202,11 @@ public class Neo4jClient implements DBClient {
 
       List<Long> result = new ArrayList<>();
       while (queryResult.hasNext()) {
-        result.add((Long) GroundType.stringToType(queryResult.next().get("f").asNode().
-            get(idAttribute).toString(), GroundType.LONG));
+        result.add(
+            (Long)
+                GroundType.stringToType(
+                    queryResult.next().get("f").asNode().get(idAttribute).toString(),
+                    GroundType.LONG));
       }
 
       return result;
@@ -200,11 +215,12 @@ public class Neo4jClient implements DBClient {
     /**
      * Get a vertex with a set of attributes and with a particular label.
      *
-     * @param label      the vertex label
+     * @param label the vertex label
      * @param attributes the attributes to filter by
      * @return the Record with the vertex
      */
-    public Record getVertex(String label, List<DbDataContainer> attributes) throws EmptyResultException {
+    public Record getVertex(String label, List<DbDataContainer> attributes)
+        throws EmptyResultException {
       String query = "MATCH (v";
       if (label == null) {
         query += " {";
@@ -226,11 +242,12 @@ public class Neo4jClient implements DBClient {
     /**
      * Retrieve an edge.
      *
-     * @param label      the edge label
+     * @param label the edge label
      * @param attributes the attributes to filter by
      * @return the Neo4j Relationship for this edge
      */
-    public Relationship getEdge(String label, List<DbDataContainer> attributes) throws EmptyResultException {
+    public Relationship getEdge(String label, List<DbDataContainer> attributes)
+        throws EmptyResultException {
       String query = "MATCH (v)-[e:" + label + "{";
 
       query = this.addValuesToStatement(query, attributes);
@@ -247,11 +264,11 @@ public class Neo4jClient implements DBClient {
     }
 
     /**
-     * Get all the edges with a particular label that are reachable from a particular
-     * starting vertex.
+     * Get all the edges with a particular label that are reachable from a particular starting
+     * vertex.
      *
      * @param startId the starting point for the query
-     * @param label   the edge label we are looking for
+     * @param label the edge label we are looking for
      * @return the list of valid edges
      */
     public List<Relationship> getDescendantEdgesByLabel(long startId, String label) {
@@ -269,22 +286,24 @@ public class Neo4jClient implements DBClient {
     }
 
     /**
-     * Get all vertices that are one edge away, where the edge connecting them has a
-     * particular label.
+     * Get all vertices that are one edge away, where the edge connecting them has a particular
+     * label.
      *
-     * @param id           the vertex to start from
-     * @param edgeLabel    the edge label we are looking for
+     * @param id the vertex to start from
+     * @param edgeLabel the edge label we are looking for
      * @param returnFields the list of fields we want to select
      * @return a list of adjacent vertices related by edgeLabel
      */
-    public List<Record> getAdjacentVerticesByEdgeLabel(String edgeLabel, long id, List<String> returnFields) {
-      String query = "MATCH (a {id: " + id + " })" +
-          "MATCH (a)-[:" + edgeLabel + "]->(b)" +
-          "RETURN ";
+    public List<Record> getAdjacentVerticesByEdgeLabel(
+        String edgeLabel, long id, List<String> returnFields) {
+      String query =
+          "MATCH (a {id: " + id + " })" + "MATCH (a)-[:" + edgeLabel + "]->(b)" + "RETURN ";
 
-      query += returnFields.stream()
-          .map(field -> "b." + field + " as " + field)
-          .collect(Collectors.joining(", "));
+      query +=
+          returnFields
+              .stream()
+              .map(field -> "b." + field + " as " + field)
+              .collect(Collectors.joining(", "));
 
       StatementResult result = this.transaction.run(query);
       return result.list();
@@ -303,13 +322,15 @@ public class Neo4jClient implements DBClient {
     }
 
     public List<Long> transitiveClosure(long nodeVersionId) throws GroundException {
-      String query = "MATCH (a: NodeVersion {id: " + nodeVersionId + "})-" +
-          "[:EdgeVersionConnection*]->(b: NodeVersion) RETURN b.id";
+      String query =
+          "MATCH (a: NodeVersion {id: "
+              + nodeVersionId
+              + "})-"
+              + "[:EdgeVersionConnection*]->(b: NodeVersion) RETURN b.id";
 
       List<Record> records = this.transaction.run(query).list();
-      List<Long> result = records.stream()
-          .map(record -> record.get("b.id").asLong())
-          .collect(Collectors.toList());
+      List<Long> result =
+          records.stream().map(record -> record.get("b.id").asLong()).collect(Collectors.toList());
 
       return result;
     }
@@ -317,9 +338,9 @@ public class Neo4jClient implements DBClient {
     /**
      * For a particular object, set a given attribute.
      *
-     * @param id       the id of the object
-     * @param key      the key of the attribute
-     * @param value    the value of the attribute
+     * @param id the id of the object
+     * @param key the key of the attribute
+     * @param value the value of the attribute
      * @param isString determines whether or not to encapsulate value in quotes
      */
     public void setProperty(long id, String key, Object value, boolean isString) {
@@ -334,17 +355,24 @@ public class Neo4jClient implements DBClient {
       this.transaction.run(insert);
     }
 
-
-    public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex) throws GroundException {
-      String query = "MATCH (n: NodeVersion {id: '" + nodeVersionId + "'})" +
-          "-[e: EdgeVersionConnection]->(evn: EdgeVersion) where evn.edge_id =~ '.*" + edgeNameRegex + ".*'" +
-          "MATCH (evn)-[f: EdgeVersionConnection]->(dst)" +
-          "return dst.id";
+    public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex)
+        throws GroundException {
+      String query =
+          "MATCH (n: NodeVersion {id: '"
+              + nodeVersionId
+              + "'})"
+              + "-[e: EdgeVersionConnection]->(evn: EdgeVersion) where evn.edge_id =~ '.*"
+              + edgeNameRegex
+              + ".*'"
+              + "MATCH (evn)-[f: EdgeVersionConnection]->(dst)"
+              + "return dst.id";
 
       List<Record> records = this.transaction.run(query).list();
-      List<Long> result = records.stream()
-          .map(record -> record.get("dst.id").asLong())
-          .collect(Collectors.toList());
+      List<Long> result =
+          records
+              .stream()
+              .map(record -> record.get("dst.id").asLong())
+              .collect(Collectors.toList());
 
       return result;
     }

--- a/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/Neo4jClient.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Neo4jClient implements DBClient, AutoCloseable {
+public class Neo4jClient extends DBClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jClient.class);
 
   private final Driver driver;

--- a/ground-core/src/main/java/edu/berkeley/ground/db/PostgresClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/PostgresClient.java
@@ -21,227 +21,211 @@ import java.sql.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class PostgresClient implements DBClient {
+public class PostgresClient implements DBClient, AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresClient.class);
-
   private static final String JDBCString = "jdbc:postgresql://%s:%d/%s?stringtype=unspecified";
-  private final String connectionString;
-  private final String username;
-  private final String password;
 
-  public PostgresClient(String host, int port, String dbName, String username, String password) {
-    this.connectionString = String.format(PostgresClient.JDBCString, host, port, dbName);
-    this.username = username;
-    this.password = password;
+  private final Connection connection;
+  private final Map<String, PreparedStatement> preparedStatements;
+
+  public PostgresClient(String host, int port, String dbName, String username, String password)
+      throws GroundDBException {
+    String url = String.format(PostgresClient.JDBCString, host, port, dbName);
+    try {
+      this.connection = DriverManager.getConnection(url, username, password);
+      this.connection.setAutoCommit(false);
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
+    }
+
+    this.preparedStatements = new HashMap<>();
   }
 
-  public PostgresConnection getConnection() throws GroundDBException {
+  /**
+   * Insert a new row into table with insertValues.
+   *
+   * @param table the table to update
+   * @param insertValues the values to put into table
+   */
+  public void insert(String table, List<DbDataContainer> insertValues) throws GroundDBException {
+    String fields =
+        insertValues.stream().map(DbDataContainer::getField).collect(Collectors.joining(", "));
+    String values = String.join(", ", Collections.nCopies(insertValues.size(), "?"));
+
+    String insert = "insert into " + table + "(" + fields + ") values (" + values + ");";
     try {
-      return new PostgresConnection(
-          DriverManager.getConnection(connectionString, username, password));
+      PreparedStatement preparedStatement = this.prepareStatement(insert);
+      int index = 1;
+      for (DbDataContainer container : insertValues) {
+        PostgresClient.setValue(
+            preparedStatement, container.getValue(), container.getGroundType(), index);
+
+        index++;
+      }
+
+      LOGGER.info("Executing update: " + preparedStatement.toString() + ".");
+
+      preparedStatement.executeUpdate();
+    } catch (SQLException e) {
+      LOGGER.error("Unexpected error in database insertion: " + e.getMessage());
+
+      throw new GroundDBException(e);
+    }
+  }
+
+  /**
+   * Retrieve rows based on a set of predicates.
+   *
+   * @param table the table to query
+   * @param projection the set of columns to retrieve
+   * @param predicatesAndValues the predicates
+   */
+  public QueryResults equalitySelect(
+      String table, List<String> projection, List<DbDataContainer> predicatesAndValues)
+      throws GroundDBException, EmptyResultException {
+    String items = String.join(", ", projection);
+    String select = "select " + items + " from " + table;
+
+    if (predicatesAndValues.size() > 0) {
+      String predicatesString =
+          predicatesAndValues
+              .stream()
+              .map(predicate -> predicate.getField() + " = ?")
+              .collect(Collectors.joining(" and "));
+      select += " where " + predicatesString;
+    }
+
+    select += ";";
+    try {
+      PreparedStatement preparedStatement = this.prepareStatement(select);
+      int index = 1;
+      for (DbDataContainer container : predicatesAndValues) {
+        PostgresClient.setValue(
+            preparedStatement, container.getValue(), container.getGroundType(), index);
+
+        index++;
+      }
+
+      LOGGER.info("Executing query: " + preparedStatement.toString() + ".");
+
+      ResultSet resultSet = preparedStatement.executeQuery();
+      if (!resultSet.isBeforeFirst()) {
+        throw new EmptyResultException(
+            "No results found for query: " + preparedStatement.toString());
+      }
+
+      // Moves the cursor to the first element so that data can be accessed directly.
+      resultSet.next();
+      return new PostgresResults(resultSet);
+    } catch (SQLException e) {
+      LOGGER.error("Unexpected error in database query: " + e.getMessage());
+
+      throw new GroundDBException(e);
+    }
+  }
+
+  @Override
+  public List<Long> transitiveClosure(long nodeVersionId) throws GroundDBException {
+    try {
+      // recursive query implementation
+      PreparedStatement statement =
+          this.prepareStatement(
+              "with recursive paths(vfrom, vto) as (\n"
+                  + "    (select from_node_version_id, to_node_version_id from edge_version where "
+                  + "     from_node_version_id = ?) "
+                  + "union\n"
+                  + "    (select p.vfrom, ev.to_node_version_id\n"
+                  + "    from paths p, edge_version ev\n"
+                  + "    where p.vto = ev.from_node_version_id)\n"
+                  + ") select vto from paths;");
+
+      statement.setLong(1, nodeVersionId);
+
+      ResultSet resultSet = statement.executeQuery();
+
+      List<Long> result = new ArrayList<>();
+      while (resultSet.next()) {
+        result.add(resultSet.getLong(1));
+      }
+
+      return result;
     } catch (SQLException e) {
       throw new GroundDBException(e);
     }
   }
 
-  public class PostgresConnection extends GroundDBConnection implements AutoCloseable {
-    private final Connection connection;
-    private final Map<String, PreparedStatement> preparedStatements;
+  public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex)
+      throws GroundDBException {
+    String query =
+        "select endpoint_two from EdgeVersions ev where ev.endpoint_one = ?"
+            + " and ev.edge_id like ?;";
 
-    public PostgresConnection(Connection connection) throws SQLException {
-      this.connection = connection;
-      this.connection.setAutoCommit(false);
+    edgeNameRegex = '%' + edgeNameRegex + '%';
 
-      this.preparedStatements = new HashMap<>();
+    try {
+      PreparedStatement statement = this.prepareStatement(query);
+      statement.setLong(1, nodeVersionId);
+      statement.setString(2, edgeNameRegex);
+
+      ResultSet resultSet = statement.executeQuery();
+      List<Long> result = new ArrayList<>();
+
+      while (resultSet.next()) {
+        result.add(resultSet.getLong(1));
+      }
+
+      return result;
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
     }
-    /**
-     * Insert a new row into table with insertValues.
-     *
-     * @param table the table to update
-     * @param insertValues the values to put into table
-     */
-    public void insert(String table, List<DbDataContainer> insertValues) throws GroundDBException {
-      String fields =
-          insertValues.stream().map(DbDataContainer::getField).collect(Collectors.joining(", "));
-      String values = String.join(", ", Collections.nCopies(insertValues.size(), "?"));
+  }
 
-      String insert = "insert into " + table + "(" + fields + ") values (" + values + ");";
-      try {
-        PreparedStatement preparedStatement = this.prepareStatement(insert);
-        int index = 1;
-        for (DbDataContainer container : insertValues) {
-          PostgresClient.setValue(
-              preparedStatement, container.getValue(), container.getGroundType(), index);
-
-          index++;
-        }
-
-        LOGGER.info("Executing update: " + preparedStatement.toString() + ".");
-
-        preparedStatement.executeUpdate();
-      } catch (SQLException e) {
-        LOGGER.error("Unexpected error in database insertion: " + e.getMessage());
-
-        throw new GroundDBException(e);
-      }
+  @Override
+  public void commit() throws GroundDBException {
+    try {
+      this.connection.commit();
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
     }
+  }
 
-    /**
-     * Retrieve rows based on a set of predicates.
-     *
-     * @param table the table to query
-     * @param projection the set of columns to retrieve
-     * @param predicatesAndValues the predicates
-     */
-    public QueryResults equalitySelect(
-        String table, List<String> projection, List<DbDataContainer> predicatesAndValues)
-        throws GroundDBException, EmptyResultException {
-      String items = String.join(", ", projection);
-      String select = "select " + items + " from " + table;
+  @Override
+  public void abort() throws GroundDBException {
+    try {
+      this.connection.rollback();
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
+    }
+  }
 
-      if (predicatesAndValues.size() > 0) {
-        String predicatesString =
-            predicatesAndValues
-                .stream()
-                .map(predicate -> predicate.getField() + " = ?")
-                .collect(Collectors.joining(" and "));
-        select += " where " + predicatesString;
+  @Override
+  public void close() throws GroundDBException {
+    try {
+      for (PreparedStatement statement : this.preparedStatements.values()) {
+        statement.close();
       }
 
-      select += ";";
-      try {
-        PreparedStatement preparedStatement = this.prepareStatement(select);
-        int index = 1;
-        for (DbDataContainer container : predicatesAndValues) {
-          PostgresClient.setValue(
-              preparedStatement, container.getValue(), container.getGroundType(), index);
+      this.connection.close();
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
+    }
+  }
 
-          index++;
-        }
-
-        LOGGER.info("Executing query: " + preparedStatement.toString() + ".");
-
-        ResultSet resultSet = preparedStatement.executeQuery();
-        if (!resultSet.isBeforeFirst()) {
-          throw new EmptyResultException(
-              "No results found for query: " + preparedStatement.toString());
-        }
-
-        // Moves the cursor to the first element so that data can be accessed directly.
-        resultSet.next();
-        return new PostgresResults(resultSet);
-      } catch (SQLException e) {
-        LOGGER.error("Unexpected error in database query: " + e.getMessage());
-
-        throw new GroundDBException(e);
-      }
+  private PreparedStatement prepareStatement(String sql) throws GroundDBException {
+    // We cannot use computeIfAbsent, as prepareStatement throws an exception.
+    // Check if the statement is already in the cache; if so, use it.
+    PreparedStatement existingStatement = this.preparedStatements.get(sql);
+    if (existingStatement != null) {
+      return existingStatement;
     }
 
-    public List<Long> transitiveClosure(long nodeVersionId) throws GroundDBException {
-      try {
-        // recursive query implementation
-        PreparedStatement statement =
-            this.prepareStatement(
-                "with recursive paths(vfrom, vto) as (\n"
-                    + "    (select from_node_version_id, to_node_version_id from edge_version where "
-                    + "     from_node_version_id = ?) "
-                    + "union\n"
-                    + "    (select p.vfrom, ev.to_node_version_id\n"
-                    + "    from paths p, edge_version ev\n"
-                    + "    where p.vto = ev.from_node_version_id)\n"
-                    + ") select vto from paths;");
-
-        statement.setLong(1, nodeVersionId);
-
-        ResultSet resultSet = statement.executeQuery();
-
-        List<Long> result = new ArrayList<>();
-        while (resultSet.next()) {
-          result.add(resultSet.getLong(1));
-        }
-
-        return result;
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
-    }
-
-    public List<Long> adjacentNodes(long nodeVersionId, String edgeNameRegex)
-        throws GroundDBException {
-      String query =
-          "select endpoint_two from EdgeVersions ev where ev.endpoint_one = ?"
-              + " and ev.edge_id like ?;";
-
-      edgeNameRegex = '%' + edgeNameRegex + '%';
-
-      try {
-        PreparedStatement statement = this.prepareStatement(query);
-        statement.setLong(1, nodeVersionId);
-        statement.setString(2, edgeNameRegex);
-
-        ResultSet resultSet = statement.executeQuery();
-        List<Long> result = new ArrayList<>();
-
-        while (resultSet.next()) {
-          result.add(resultSet.getLong(1));
-        }
-
-        return result;
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
-    }
-
-    @Override
-    public void commit() throws GroundDBException {
-      try {
-        this.connection.commit();
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
-
-      this.close();
-    }
-
-    @Override
-    public void abort() throws GroundDBException {
-      try {
-        this.connection.rollback();
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
-
-      this.close();
-    }
-
-    @Override
-    public void close() throws GroundDBException {
-      try {
-        this.connection.close();
-        for (PreparedStatement statement : this.preparedStatements.values()) {
-          statement.close();
-        }
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
-    }
-
-    private PreparedStatement prepareStatement(String sql) throws GroundDBException {
-      // We cannot use computeIfAbsent, as prepareStatement throws an exception.
-      // Check if the statement is already in the cache; if so, use it.
-      PreparedStatement existingStatement = this.preparedStatements.get(sql);
-      if (existingStatement != null) {
-        return existingStatement;
-      }
-
-      try {
-        // Otherwise, prepare the statement, then cache it.
-        PreparedStatement newStatement = this.connection.prepareStatement(sql);
-        this.preparedStatements.put(sql, newStatement);
-        return newStatement;
-      } catch (SQLException e) {
-        throw new GroundDBException(e);
-      }
+    try {
+      // Otherwise, prepare the statement, then cache it.
+      PreparedStatement newStatement = this.connection.prepareStatement(sql);
+      this.preparedStatements.put(sql, newStatement);
+      return newStatement;
+    } catch (SQLException e) {
+      throw new GroundDBException(e);
     }
   }
 

--- a/ground-core/src/main/java/edu/berkeley/ground/db/PostgresClient.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/PostgresClient.java
@@ -21,7 +21,7 @@ import java.sql.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class PostgresClient implements DBClient, AutoCloseable {
+public class PostgresClient extends DBClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresClient.class);
   private static final String JDBCString = "jdbc:postgresql://%s:%d/%s?stringtype=unspecified";
 

--- a/ground-core/src/main/java/edu/berkeley/ground/db/PostgresResults.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/PostgresResults.java
@@ -14,7 +14,7 @@
 
 package edu.berkeley.ground.db;
 
-import edu.berkeley.ground.exceptions.GroundException;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.slf4j.Logger;
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class PostgresResults implements QueryResults {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresResults.class);
@@ -34,60 +32,60 @@ public class PostgresResults implements QueryResults {
     this.resultSet = resultSet;
   }
 
-  public boolean next() throws GroundException {
+  public boolean next() throws GroundDBException {
     try {
       return this.resultSet.next();
     } catch (SQLException e) {
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public String getString(int index) throws GroundException {
+  public String getString(int index) throws GroundDBException {
     try {
       return resultSet.getString(index);
     } catch (SQLException e) {
       LOGGER.error(e.getMessage());
 
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public String getString(String field) throws GroundException {
+  public String getString(String field) {
     throw new NotImplementedException();
   }
 
 
-  public long getLong(String field) throws GroundException {
+  public long getLong(String field) {
     throw new NotImplementedException();
   }
 
-  public int getInt(int index) throws GroundException {
+  public int getInt(int index) throws GroundDBException {
     try {
       return resultSet.getInt(index);
     } catch (SQLException e) {
       LOGGER.error(e.getMessage());
 
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public boolean getBoolean(int index) throws GroundException {
+  public boolean getBoolean(int index) throws GroundDBException {
     try {
       return resultSet.getBoolean(index);
     } catch (SQLException e) {
       LOGGER.error(e.getMessage());
 
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 
-  public long getLong(int index) throws GroundException {
+  public long getLong(int index) throws GroundDBException {
     try {
       return resultSet.getLong(index);
     } catch (SQLException e) {
       LOGGER.error(e.getMessage());
 
-      throw new GroundException(e);
+      throw new GroundDBException(e);
     }
   }
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/db/QueryResults.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/db/QueryResults.java
@@ -14,22 +14,20 @@
 
 package edu.berkeley.ground.db;
 
-import edu.berkeley.ground.exceptions.GroundException;
-
-import java.util.List;
+import edu.berkeley.ground.exceptions.GroundDBException;
 
 public interface QueryResults {
-  String getString(int index) throws GroundException;
+  String getString(int index) throws GroundDBException;
 
-  String getString(String field) throws GroundException;
+  String getString(String field) throws GroundDBException;
 
-  int getInt(int index) throws GroundException;
+  int getInt(int index) throws GroundDBException;
 
-  boolean getBoolean(int index) throws GroundException;
+  boolean getBoolean(int index) throws GroundDBException;
 
-  long getLong(int index) throws GroundException;
+  long getLong(int index) throws GroundDBException;
 
-  long getLong(String field) throws GroundException;
+  long getLong(String field) throws GroundDBException;
 
-  boolean next() throws GroundException;
+  boolean next() throws GroundDBException;
 }

--- a/ground-core/src/main/java/edu/berkeley/ground/util/CassandraFactories.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/util/CassandraFactories.java
@@ -42,15 +42,15 @@ public class CassandraFactories {
   public CassandraFactories(CassandraClient cassandraClient, int machineId, int numMachines) {
     IdGenerator idGenerator = new IdGenerator(machineId, numMachines, false);
 
-    CassandraVersionFactory versionFactory = new CassandraVersionFactory();
-    CassandraVersionSuccessorFactory versionSuccessorFactory = new CassandraVersionSuccessorFactory(idGenerator);
-    CassandraVersionHistoryDAGFactory versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(versionSuccessorFactory);
-    CassandraTagFactory tagFactory = new CassandraTagFactory();
-    CassandraItemFactory itemFactory = new CassandraItemFactory(versionHistoryDAGFactory, tagFactory);
+    CassandraVersionFactory versionFactory = new CassandraVersionFactory(cassandraClient);
+    CassandraVersionSuccessorFactory versionSuccessorFactory = new CassandraVersionSuccessorFactory(cassandraClient, idGenerator);
+    CassandraVersionHistoryDAGFactory versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(cassandraClient, versionSuccessorFactory);
+    CassandraTagFactory tagFactory = new CassandraTagFactory(cassandraClient);
+    CassandraItemFactory itemFactory = new CassandraItemFactory(cassandraClient, versionHistoryDAGFactory, tagFactory);
 
     this.structureFactory = new CassandraStructureFactory(itemFactory, cassandraClient, idGenerator);
     this.structureVersionFactory = new CassandraStructureVersionFactory(this.structureFactory, versionFactory, cassandraClient, idGenerator);
-    CassandraRichVersionFactory richVersionFactory = new CassandraRichVersionFactory(versionFactory, structureVersionFactory, tagFactory);
+    CassandraRichVersionFactory richVersionFactory = new CassandraRichVersionFactory(cassandraClient, versionFactory, structureVersionFactory, tagFactory);
     this.edgeFactory = new CassandraEdgeFactory(itemFactory, cassandraClient, idGenerator);
     this.edgeVersionFactory = new CassandraEdgeVersionFactory(this.edgeFactory, richVersionFactory, cassandraClient, idGenerator);
     this.graphFactory = new CassandraGraphFactory(itemFactory, cassandraClient, idGenerator);

--- a/ground-core/src/main/java/edu/berkeley/ground/util/Neo4jFactories.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/util/Neo4jFactories.java
@@ -41,14 +41,14 @@ public class Neo4jFactories {
   public Neo4jFactories(Neo4jClient neo4jClient, int machineId, int numMachines) {
     IdGenerator idGenerator = new IdGenerator(machineId, numMachines, true);
 
-    Neo4jVersionSuccessorFactory versionSuccessorFactory = new Neo4jVersionSuccessorFactory(idGenerator);
-    Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory = new Neo4jVersionHistoryDAGFactory(versionSuccessorFactory);
-    Neo4jTagFactory tagFactory = new Neo4jTagFactory();
-    Neo4jItemFactory itemFactory = new Neo4jItemFactory(versionHistoryDAGFactory, tagFactory);
+    Neo4jVersionSuccessorFactory versionSuccessorFactory = new Neo4jVersionSuccessorFactory(neo4jClient, idGenerator);
+    Neo4jVersionHistoryDAGFactory versionHistoryDAGFactory = new Neo4jVersionHistoryDAGFactory(neo4jClient, versionSuccessorFactory);
+    Neo4jTagFactory tagFactory = new Neo4jTagFactory(neo4jClient);
+    Neo4jItemFactory itemFactory = new Neo4jItemFactory(neo4jClient, versionHistoryDAGFactory, tagFactory);
 
     this.structureFactory = new Neo4jStructureFactory(neo4jClient, itemFactory, idGenerator);
     this.structureVersionFactory = new Neo4jStructureVersionFactory(neo4jClient, this.structureFactory, idGenerator);
-    Neo4jRichVersionFactory richVersionFactory = new Neo4jRichVersionFactory(structureVersionFactory, tagFactory);
+    Neo4jRichVersionFactory richVersionFactory = new Neo4jRichVersionFactory(neo4jClient, structureVersionFactory, tagFactory);
     this.edgeFactory = new Neo4jEdgeFactory(itemFactory, neo4jClient, idGenerator);
     this.edgeVersionFactory = new Neo4jEdgeVersionFactory(this.edgeFactory, richVersionFactory, neo4jClient, idGenerator);
     this.graphFactory = new Neo4jGraphFactory(neo4jClient, itemFactory, idGenerator);

--- a/ground-core/src/main/java/edu/berkeley/ground/util/PostgresFactories.java
+++ b/ground-core/src/main/java/edu/berkeley/ground/util/PostgresFactories.java
@@ -42,15 +42,15 @@ public class PostgresFactories {
   public PostgresFactories(PostgresClient postgresClient, int machineId, int numMachines) {
     IdGenerator idGenerator = new IdGenerator(machineId, numMachines, false);
 
-    PostgresVersionFactory versionFactory = new PostgresVersionFactory();
-    PostgresVersionSuccessorFactory versionSuccessorFactory = new PostgresVersionSuccessorFactory(idGenerator);
-    PostgresVersionHistoryDAGFactory versionHistoryDAGFactory = new PostgresVersionHistoryDAGFactory(versionSuccessorFactory);
-    PostgresTagFactory tagFactory = new PostgresTagFactory();
-    PostgresItemFactory itemFactory = new PostgresItemFactory(versionHistoryDAGFactory, tagFactory);
+    PostgresVersionFactory versionFactory = new PostgresVersionFactory(postgresClient);
+    PostgresVersionSuccessorFactory versionSuccessorFactory = new PostgresVersionSuccessorFactory(postgresClient, idGenerator);
+    PostgresVersionHistoryDAGFactory versionHistoryDAGFactory = new PostgresVersionHistoryDAGFactory(postgresClient, versionSuccessorFactory);
+    PostgresTagFactory tagFactory = new PostgresTagFactory(postgresClient);
+    PostgresItemFactory itemFactory = new PostgresItemFactory(postgresClient, versionHistoryDAGFactory, tagFactory);
 
     this.structureFactory = new PostgresStructureFactory(itemFactory, postgresClient, idGenerator);
     this.structureVersionFactory = new PostgresStructureVersionFactory(this.structureFactory, versionFactory, postgresClient, idGenerator);
-    PostgresRichVersionFactory richVersionFactory = new PostgresRichVersionFactory(versionFactory, structureVersionFactory, tagFactory);
+    PostgresRichVersionFactory richVersionFactory = new PostgresRichVersionFactory(postgresClient, versionFactory, structureVersionFactory, tagFactory);
     this.edgeFactory = new PostgresEdgeFactory(itemFactory, postgresClient, idGenerator);
     this.edgeVersionFactory = new PostgresEdgeVersionFactory(this.edgeFactory, richVersionFactory, postgresClient, idGenerator);
     this.graphFactory = new PostgresGraphFactory(itemFactory, postgresClient, idGenerator);

--- a/ground-core/src/test/java/edu/berkeley/ground/api/CassandraTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/CassandraTest.java
@@ -36,13 +36,13 @@ public class CassandraTest {
     cassandraClient = new CassandraClient("localhost", 9160, "test", "test", "");
     factories = new CassandraFactories(cassandraClient, 0, 1);
 
-    versionFactory = new CassandraVersionFactory();
-    versionSuccessorFactory = new CassandraVersionSuccessorFactory(new IdGenerator(0, 1, false));
-    versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(versionSuccessorFactory);
-    tagFactory = new CassandraTagFactory();
-    itemFactory = new CassandraItemFactory(versionHistoryDAGFactory, tagFactory);
+    versionFactory = new CassandraVersionFactory(cassandraClient);
+    versionSuccessorFactory = new CassandraVersionSuccessorFactory(cassandraClient, new IdGenerator(0, 1, false));
+    versionHistoryDAGFactory = new CassandraVersionHistoryDAGFactory(cassandraClient, versionSuccessorFactory);
+    tagFactory = new CassandraTagFactory(cassandraClient);
+    itemFactory = new CassandraItemFactory(cassandraClient, versionHistoryDAGFactory, tagFactory);
 
-    richVersionFactory = new CassandraRichVersionFactory(versionFactory,
+    richVersionFactory = new CassandraRichVersionFactory(cassandraClient, versionFactory,
         (CassandraStructureVersionFactory) factories.getStructureVersionFactory(), tagFactory);
   }
 
@@ -56,6 +56,6 @@ public class CassandraTest {
 
   @AfterClass
   public static void tearDown() throws IOException, InterruptedException {
-    cassandraClient.closeCluster();
+    cassandraClient.close();
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/Neo4jTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/Neo4jTest.java
@@ -33,12 +33,12 @@ public class Neo4jTest {
 
   public Neo4jTest() {
     this.neo4jClient = new Neo4jClient("localhost", "neo4j", "password");
-    this.factories = new Neo4jFactories(neo4jClient, 0, 1);
-    this.versionSuccessorFactory = new Neo4jVersionSuccessorFactory(new IdGenerator(0, 1, true));
-    this.versionHistoryDAGFactory = new Neo4jVersionHistoryDAGFactory(this.versionSuccessorFactory);
-    this.tagFactory = new Neo4jTagFactory();
-    this.itemFactory = new Neo4jItemFactory(this.versionHistoryDAGFactory, tagFactory);
-    this.richVersionFactory = new Neo4jRichVersionFactory((Neo4jStructureVersionFactory)
+    this.factories = new Neo4jFactories(this.neo4jClient, 0, 1);
+    this.versionSuccessorFactory = new Neo4jVersionSuccessorFactory(this.neo4jClient, new IdGenerator(0, 1, true));
+    this.versionHistoryDAGFactory = new Neo4jVersionHistoryDAGFactory(this.neo4jClient, this.versionSuccessorFactory);
+    this.tagFactory = new Neo4jTagFactory(this.neo4jClient);
+    this.itemFactory = new Neo4jItemFactory(this.neo4jClient, this.versionHistoryDAGFactory, tagFactory);
+    this.richVersionFactory = new Neo4jRichVersionFactory(this.neo4jClient, (Neo4jStructureVersionFactory)
         this.factories.getStructureVersionFactory(), this.tagFactory);
   }
 

--- a/ground-core/src/test/java/edu/berkeley/ground/api/PostgresTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/PostgresTest.java
@@ -31,15 +31,15 @@ public class PostgresTest {
 
   public PostgresTest() throws GroundDBException {
     this.postgresClient = new PostgresClient("localhost", 5432, "test", "test", "");
-    this.factories = new PostgresFactories(postgresClient, 0, 1);
+    this.factories = new PostgresFactories(this.postgresClient, 0, 1);
 
-    this.versionFactory = new PostgresVersionFactory();
-    this.versionSuccessorFactory = new PostgresVersionSuccessorFactory(new IdGenerator(0, 1, false));
-    this.versionHistoryDAGFactory = new PostgresVersionHistoryDAGFactory(versionSuccessorFactory);
-    this.tagFactory = new PostgresTagFactory();
-    this.itemFactory = new PostgresItemFactory(versionHistoryDAGFactory, tagFactory);
+    this.versionFactory = new PostgresVersionFactory(this.postgresClient);
+    this.versionSuccessorFactory = new PostgresVersionSuccessorFactory(this.postgresClient, new IdGenerator(0, 1, false));
+    this.versionHistoryDAGFactory = new PostgresVersionHistoryDAGFactory(this.postgresClient, versionSuccessorFactory);
+    this.tagFactory = new PostgresTagFactory(this.postgresClient);
+    this.itemFactory = new PostgresItemFactory(this.postgresClient, versionHistoryDAGFactory, tagFactory);
 
-    this.richVersionFactory = new PostgresRichVersionFactory(versionFactory,
+    this.richVersionFactory = new PostgresRichVersionFactory(this.postgresClient, versionFactory,
         (PostgresStructureVersionFactory) factories.getStructureVersionFactory(), tagFactory);
   }
 

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraRichVersionFactoryTest.java
@@ -10,7 +10,6 @@ import edu.berkeley.ground.api.CassandraTest;
 import edu.berkeley.ground.api.models.RichVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -23,18 +22,15 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
 
   @Test
   public void testReference() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
-      connection = super.cassandraClient.getConnection();
       long id = 1;
       String testReference = "http://www.google.com";
       Map<String, String> parameters = new HashMap<>();
       parameters.put("http", "GET");
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, new HashMap<>(), -1, testReference, parameters);
+      super.richVersionFactory.insertIntoDatabase(id, new HashMap<>(), -1, testReference, parameters);
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(testReference, retrieved.getReference());
@@ -45,16 +41,13 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
         assertEquals(parameters.get(key), retrievedParams.get(key));
       }
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
-      connection = super.cassandraClient.getConnection();
       long id = 1;
 
       Map<String, Tag> tags = new HashMap<>();
@@ -63,9 +56,9 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
       tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
       tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, -1, null, new HashMap<>());
+      super.richVersionFactory.insertIntoDatabase(id, tags, -1, null, new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -77,15 +70,13 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testStructureVersionConformation() throws GroundException {
-    CassandraConnection connection = null;
     try {
-      connection = super.cassandraClient.getConnection();
       long id = 1;
 
       String structureName = "testStructure";
@@ -104,28 +95,24 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
       tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
       tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
       assertEquals(retrieved.getStructureVersionId(), structureVersionId);
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testStructureVersionFails() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
       long structureVersionId = -1;
       long id = 1;
 
       // none of these operations should fail
       try {
-        connection = super.cassandraClient.getConnection();
-
         String structureName = "testStructure";
         long structureId = super.factories.getStructureFactory().create(structureName, new HashMap<>()).getId();
 
@@ -136,7 +123,7 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
 
         structureVersionId = super.factories.getStructureVersionFactory().create(structureId, structureVersionAttributes, new ArrayList<>()).getId();
       } catch (GroundException ge) {
-        connection.abort();
+        super.cassandraClient.abort();
 
         fail(ge.getMessage());
       }
@@ -147,10 +134,10 @@ public class CassandraRichVersionFactoryTest extends CassandraTest {
       tags.put("intfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
       // this should fail
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraTagFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/cassandra/CassandraTagFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import edu.berkeley.ground.api.CassandraTest;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -29,10 +28,9 @@ public class CassandraTagFactoryTest extends CassandraTest {
     long nodeId1 = CassandraTest.factories.getNodeFactory().create("test1", tagsMap).getId();
     long nodeId2 = CassandraTest.factories.getNodeFactory().create("test2", tagsMap).getId();
 
-    CassandraConnection connection = CassandraTest.cassandraClient.getConnection();
-    List<Long> ids = CassandraTest.tagFactory.getItemIdsByTag(connection, "testtag");
+    List<Long> ids = CassandraTest.tagFactory.getItemIdsByTag("testtag");
 
-    connection.commit();
+    super.cassandraClient.commit();
 
     assertTrue(ids.contains(nodeId1));
     assertTrue(ids.contains(nodeId2));
@@ -50,10 +48,9 @@ public class CassandraTagFactoryTest extends CassandraTest {
     long nodeVersionId2 = CassandraTest.factories.getNodeVersionFactory().create(tagsMap,
         -1, null, new HashMap<>(), nodeId, new ArrayList<>()).getId();
 
-    CassandraConnection connection = CassandraTest.cassandraClient.getConnection();
-    List<Long> ids = CassandraTest.tagFactory.getVersionIdsByTag(connection, "testtag");
+    List<Long> ids = CassandraTest.tagFactory.getVersionIdsByTag("testtag");
 
-    connection.commit();
+    super.cassandraClient.commit();
 
     assertTrue(ids.contains(nodeVersionId1));
     assertTrue(ids.contains(nodeVersionId2));

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jNodeFactoryTest.java
@@ -12,7 +12,6 @@ import edu.berkeley.ground.api.models.Node;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.Item;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -40,18 +39,14 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
 
   @Test
   public void testNodeTagRetrieval() throws GroundException {
-    Neo4jConnection connection = null;
-
     try {
-      connection = super.neo4jClient.getConnection();
-
       Map<String, Tag> tags = new HashMap<>();
       tags.put("intfield", new Tag(-1, "intfield", 1, GroundType.INTEGER));
       tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
       tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
       long testNodeId = super.factories.getNodeFactory().create("testNode", tags).getId();
-      Item retrieved = super.itemFactory.retrieveFromDatabase(connection, testNodeId);
+      Item retrieved = super.itemFactory.retrieveFromDatabase(testNodeId);
 
       assertEquals(testNodeId, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -63,7 +58,7 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jRichVersionFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jRichVersionFactoryTest.java
@@ -10,7 +10,6 @@ import edu.berkeley.ground.api.Neo4jTest;
 import edu.berkeley.ground.api.models.RichVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -23,10 +22,7 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
 
   @Test
   public void testReference() throws GroundException {
-    Neo4jConnection connection = null;
     try {
-      connection = super.neo4jClient.getConnection();
-
       /* Create a NodeVersion because Neo4j's rich version factory looks for an existing version with this id */
       long testNodeId = super.factories.getNodeFactory().create("testNode", new HashMap<>()).getId();
       long id = super.createNodeVersion(testNodeId);
@@ -35,9 +31,9 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
       Map<String, String> parameters = new HashMap<>();
       parameters.put("http", "GET");
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, new HashMap<>(), -1, testReference, parameters);
+      super.richVersionFactory.insertIntoDatabase(id, new HashMap<>(), -1, testReference, parameters);
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(testReference, retrieved.getReference());
@@ -48,16 +44,13 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
         assertEquals(parameters.get(key), retrievedParams.get(key));
       }
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    Neo4jConnection connection = null;
     try {
-      connection = super.neo4jClient.getConnection();
-
       /* Create a NodeVersion because Neo4j's rich version factory looks for an existing version with this id */
       long testNodeId = super.factories.getNodeFactory().create("testNode", new HashMap<>()).getId();
       long id = super.createNodeVersion(testNodeId);
@@ -68,9 +61,9 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
       tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
       tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, -1, null, new HashMap<>());
+      super.richVersionFactory.insertIntoDatabase(id, tags, -1, null, new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -82,16 +75,13 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 
   @Test
   public void testStructureVersionConformation() throws GroundException {
-    Neo4jConnection connection = null;
     try {
-      connection = super.neo4jClient.getConnection();
-
       /* Create a NodeVersion because Neo4j's rich version factory looks for an existing * version with this id */
       long testNodeId = super.factories.getNodeFactory().create("testNode", new HashMap<>()).getId();
       long id = super.createNodeVersion(testNodeId);
@@ -112,20 +102,19 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
       tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
       tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
       assertEquals(retrieved.getStructureVersionId(), structureVersionId);
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testStructureVersionFails() throws GroundException {
     long structureVersionId = -1;
-    Neo4jConnection connection = null;
 
     try {
       /* Create a NodeVersion because Neo4j's rich version factory looks for an existing version with this id */
@@ -134,8 +123,6 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
 
       // none of these operations should fail
       try {
-        connection = super.neo4jClient.getConnection();
-
         String structureName = "testStructure";
         long structureId = super.factories.getStructureFactory().create(structureName, new HashMap<>()).getId();
 
@@ -156,10 +143,10 @@ public class Neo4jRichVersionFactoryTest extends Neo4jTest {
       tags.put("intfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
       // this should fail
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jTagFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/neo4j/Neo4jTagFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import edu.berkeley.ground.api.Neo4jTest;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -29,10 +28,9 @@ public class Neo4jTagFactoryTest extends Neo4jTest {
     long nodeId1 = super.factories.getNodeFactory().create("test1", tagsMap).getId();
     long nodeId2 = super.factories.getNodeFactory().create("test2", tagsMap).getId();
 
-    Neo4jConnection connection = super.neo4jClient.getConnection();
-    List<Long> ids = super.tagFactory.getItemIdsByTag(connection, "testtag");
+    List<Long> ids = super.tagFactory.getItemIdsByTag("testtag");
 
-    connection.commit();
+    super.neo4jClient.commit();
 
     assertTrue(ids.contains(nodeId1));
     assertTrue(ids.contains(nodeId2));
@@ -50,10 +48,9 @@ public class Neo4jTagFactoryTest extends Neo4jTest {
     long nodeVersionId2 = super.factories.getNodeVersionFactory().create(tagsMap,
         -1, null, new HashMap<>(), nodeId, new ArrayList<>()).getId();
 
-    Neo4jConnection connection = super.neo4jClient.getConnection();
-    List<Long> ids = super.tagFactory.getVersionIdsByTag(connection, "testtag");
+    List<Long> ids = super.tagFactory.getVersionIdsByTag("testtag");
 
-    connection.commit();
+    super.neo4jClient.commit();
 
     assertTrue(ids.contains(nodeVersionId1));
     assertTrue(ids.contains(nodeVersionId2));

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/postgres/PostgresRichVersionFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/postgres/PostgresRichVersionFactoryTest.java
@@ -10,7 +10,6 @@ import edu.berkeley.ground.api.PostgresTest;
 import edu.berkeley.ground.api.models.RichVersion;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -23,19 +22,16 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
 
   @Test
   public void testReference() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
-      connection = super.postgresClient.getConnection();
       long id = 1;
       String testReference = "http://www.google.com";
       Map<String, String> parameters = new HashMap<>();
       parameters.put("http", "GET");
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, new HashMap<>(), -1,
+      super.richVersionFactory.insertIntoDatabase(id, new HashMap<>(), -1,
           testReference, parameters);
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(testReference, retrieved.getReference());
@@ -46,16 +42,13 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
         assertEquals(parameters.get(key), retrievedParams.get(key));
       }
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
-      connection = super.postgresClient.getConnection();
       long id = 1;
 
       Map<String, Tag> tags = new HashMap<>();
@@ -64,10 +57,10 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
       tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
       tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, -1,
+      super.richVersionFactory.insertIntoDatabase(id, tags, -1,
           null, new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
 
       assertEquals(id, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -79,15 +72,13 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testStructureVersionConformation() throws GroundException {
-    PostgresConnection connection = null;
     try {
-      connection = super.postgresClient.getConnection();
       long id = 2;
 
       String structureName = "testStructure";
@@ -106,28 +97,24 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
       tags.put("strfield", new Tag(-1, "strfield", "1", GroundType.STRING));
       tags.put("boolfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
 
-      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(connection, id);
+      RichVersion retrieved = super.richVersionFactory.retrieveFromDatabase(id);
       assertEquals(retrieved.getStructureVersionId(), structureVersionId);
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testStructureVersionFails() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
       long structureVersionId = -1;
       long id = 1;
 
       // none of these operations should fail
       try {
-        connection = super.postgresClient.getConnection();
-
         String structureName = "testStructure";
         long structureId = super.factories.getStructureFactory().create(structureName, new HashMap<>()).getId();
 
@@ -148,10 +135,10 @@ public class PostgresRichVersionFactoryTest extends PostgresTest {
       tags.put("intfield", new Tag(-1, "boolfield", true, GroundType.BOOLEAN));
 
       // this should fail
-      super.richVersionFactory.insertIntoDatabase(connection, id, tags, structureVersionId, null,
+      super.richVersionFactory.insertIntoDatabase(id, tags, structureVersionId, null,
           new HashMap<>());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/models/postgres/PostgresTagFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/models/postgres/PostgresTagFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import edu.berkeley.ground.api.PostgresTest;
 import edu.berkeley.ground.api.models.Tag;
 import edu.berkeley.ground.api.versions.GroundType;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -29,10 +28,9 @@ public class PostgresTagFactoryTest extends PostgresTest {
     long nodeId1 = super.factories.getNodeFactory().create("test1", tagsMap).getId();
     long nodeId2 = super.factories.getNodeFactory().create("test2", tagsMap).getId();
 
-    PostgresConnection connection = super.postgresClient.getConnection();
-    List<Long> ids = super.tagFactory.getItemIdsByTag(connection, "testtag");
+    List<Long> ids = super.tagFactory.getItemIdsByTag("testtag");
 
-    connection.commit();
+    super.postgresClient.commit();
 
     assertTrue(ids.contains(nodeId1));
     assertTrue(ids.contains(nodeId2));
@@ -50,10 +48,9 @@ public class PostgresTagFactoryTest extends PostgresTest {
     long nodeVersionId2 = super.factories.getNodeVersionFactory().create(tagsMap,
         -1, null, new HashMap<>(), nodeId, new ArrayList<>()).getId();
 
-    PostgresConnection connection = super.postgresClient.getConnection();
-    List<Long> ids = super.tagFactory.getVersionIdsByTag(connection, "testtag");
+    List<Long> ids = super.tagFactory.getVersionIdsByTag("testtag");
 
-    connection.commit();
+    super.postgresClient.commit();
 
     assertTrue(ids.contains(nodeVersionId1));
     assertTrue(ids.contains(nodeVersionId2));

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraItemFactoryTest.java
@@ -13,7 +13,6 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.Item;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -28,38 +27,35 @@ public class CassandraItemFactoryTest extends CassandraTest {
 
   @Test
   public void testCorrectUpdateWithParent() throws GroundException {
-    CassandraConnection connection = null;
     try {
       long testId = 1;
-      connection = super.cassandraClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long fromId = 123;
       long toId = 456;
 
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
 
       List<Long> parentIds = new ArrayList<>();
       parentIds.add(0L);
-      super.itemFactory.update(connection, testId, fromId, new ArrayList<>());
+      super.itemFactory.update(testId, fromId, new ArrayList<>());
 
       parentIds.clear();
       parentIds.add(fromId);
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(2, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> successor = null;
       for (long id : dag.getEdgeIds()) {
-        successor = super.versionSuccessorFactory.retrieveFromDatabase(connection, id);
+        successor = super.versionSuccessorFactory.retrieveFromDatabase(id);
 
-        if (!(successor.getFromId() == 0)) {
+        if (successor.getFromId() != 0) {
           break;
         }
       }
@@ -71,82 +67,74 @@ public class CassandraItemFactoryTest extends CassandraTest {
       assertEquals(fromId, successor.getFromId());
       assertEquals(toId, successor.getToId());
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testCorrectUpdateWithoutParent() throws GroundException {
-    CassandraConnection connection = null;
     try {
       long testId = 1;
-      connection = super.cassandraClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
       long toId = 123;
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(toId);
 
       List<Long> parentIds = new ArrayList<>();
 
       // No parent is specified, and there is no other version in this Item, we should
       // automatically make this a child of EMPTY
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(1, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(0));
+          dag.getEdgeIds().get(0));
 
       assertEquals(0, successor.getFromId());
       assertEquals(toId, successor.getToId());
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testCorrectUpdateWithLinearHistory() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
       long testId = 1;
-      connection = super.cassandraClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long fromId = 123;
       long toId = 456;
 
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
       List<Long> parentIds = new ArrayList<>();
 
       // first, make from a child of EMPTY
-      super.itemFactory.update(connection, testId, fromId, parentIds);
-
+      super.itemFactory.update(testId, fromId, parentIds);
 
       // then, add to as a child and make sure that it becomes a child of from
       parentIds = new ArrayList<>();
       parentIds.add(fromId);
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(2, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> toSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(0));
+          dag.getEdgeIds().get(0));
 
       VersionSuccessor<?> fromSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(1));
+          dag.getEdgeIds().get(1));
 
-      if (!(fromSuccessor.getFromId() == 0)) {
+      if (fromSuccessor.getFromId() != 0) {
         VersionSuccessor<?> tmp = fromSuccessor;
         fromSuccessor = toSuccessor;
         toSuccessor = tmp;
@@ -158,24 +146,21 @@ public class CassandraItemFactoryTest extends CassandraTest {
       assertEquals(fromId, toSuccessor.getFromId());
       assertEquals(toId, toSuccessor.getToId());
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testIncorrectUpdate() throws GroundException {
-    CassandraConnection connection = null;
     try {
       long testId = 1;
       long fromId = 123;
       long toId = 456;
 
       try {
-        connection = super.cassandraClient.getConnection();
+        super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
-        super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
-
-        super.versionFactory.insertIntoDatabase(connection, toId);
+        super.versionFactory.insertIntoDatabase(toId);
 
       } catch (GroundException ge) {
         fail(ge.getMessage());
@@ -185,42 +170,39 @@ public class CassandraItemFactoryTest extends CassandraTest {
       parentIds.add(fromId);
 
       // this should fail because fromId is not a valid version
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testMultipleParents() throws GroundException {
-    CassandraConnection connection = null;
     try {
       long testId = 1;
-      connection = super.cassandraClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long parentOne = 123;
       long parentTwo = 456;
       long child = 789;
 
-      super.versionFactory.insertIntoDatabase(connection, parentOne);
-      super.versionFactory.insertIntoDatabase(connection, parentTwo);
-      super.versionFactory.insertIntoDatabase(connection, child);
+      super.versionFactory.insertIntoDatabase(parentOne);
+      super.versionFactory.insertIntoDatabase(parentTwo);
+      super.versionFactory.insertIntoDatabase(child);
       List<Long> parentIds = new ArrayList<>();
 
       // first, make the parents children of EMPTY
-      super.itemFactory.update(connection, testId, parentOne, parentIds);
-      super.itemFactory.update(connection, testId, parentTwo, parentIds);
+      super.itemFactory.update(testId, parentOne, parentIds);
+      super.itemFactory.update(testId, parentTwo, parentIds);
 
       // then, add to as a child and make sure that it becomes a child of from
       parentIds = new ArrayList<>();
       parentIds.add(parentOne);
       parentIds.add(parentTwo);
-      super.itemFactory.update(connection, testId, child, parentIds);
+      super.itemFactory.update(testId, child, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(4, dag.getEdgeIds().size());
       assertEquals(1, dag.getLeaves().size());
@@ -228,27 +210,23 @@ public class CassandraItemFactoryTest extends CassandraTest {
 
       // No need to check the version successors because we have tests for those.
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
       long testId = 1;
-      connection = super.cassandraClient.getConnection();
       Map<String, Tag> tags = new HashMap<>();
       tags.put("justkey", new Tag(-1, "justkey", null, null));
       tags.put("withintvalue", new Tag(-1, "withintvalue", 1, GroundType.INTEGER));
       tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
       tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
+      super.itemFactory.insertIntoDatabase(testId, tags);
 
-      super.itemFactory.insertIntoDatabase(connection, testId, tags);
-
-      Item retrieved = super.itemFactory.retrieveFromDatabase(connection, testId);
+      Item retrieved = super.itemFactory.retrieveFromDatabase(testId);
 
       assertEquals(testId, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -260,7 +238,7 @@ public class CassandraItemFactoryTest extends CassandraTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/cassandra/CassandraVersionSuccessorFactoryTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import edu.berkeley.ground.api.CassandraTest;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.CassandraClient.CassandraConnection;
 import edu.berkeley.ground.exceptions.GroundDBException;
 import edu.berkeley.ground.exceptions.GroundException;
 
@@ -18,32 +17,27 @@ public class CassandraVersionSuccessorFactoryTest extends CassandraTest {
 
   @Test
   public void testVersionSuccessorCreation() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
       long fromId = 123;
       long toId = 456;
 
-      connection = super.cassandraClient.getConnection();
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
 
-      VersionSuccessor<?> successor = super.versionSuccessorFactory.create(connection, fromId, toId);
+      VersionSuccessor<?> successor = super.versionSuccessorFactory.create(fromId, toId);
 
-      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(connection,
+      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(
           successor.getId());
 
       assertEquals(fromId, retrieved.getFromId());
       assertEquals(toId, retrieved.getToId());
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testBadVersionSuccessorCreation() throws GroundException {
-    CassandraConnection connection = null;
-
     try {
       long fromId = 123;
       long toId = 456;
@@ -51,18 +45,17 @@ public class CassandraVersionSuccessorFactoryTest extends CassandraTest {
       // Catch exceptions for these two lines because they should not fal
       try {
         // the main difference is that we're not creating a Version for the toId
-        connection = super.cassandraClient.getConnection();
-        super.versionFactory.insertIntoDatabase(connection, fromId);
+        super.versionFactory.insertIntoDatabase(fromId);
       } catch (GroundException ge) {
-        connection.abort();
+        super.cassandraClient.abort();
 
         fail(ge.getMessage());
       }
 
       // This statement should fail because toId is not in the database
-      super.versionSuccessorFactory.create(connection, fromId, toId);
+      super.versionSuccessorFactory.create(fromId, toId);
     } finally {
-      connection.abort();
+      super.cassandraClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionHistoryDAGFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionHistoryDAGFactoryTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import edu.berkeley.ground.api.Neo4jTest;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -17,17 +16,15 @@ public class Neo4jVersionHistoryDAGFactoryTest extends Neo4jTest {
 
   @Test
   public void testVersionHistoryDAGCreation() throws GroundException {
-    Neo4jConnection connection = null;
     try {
       long testId = 1;
       super.versionHistoryDAGFactory.create(testId);
-      connection = super.neo4jClient.getConnection();
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection, testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(0, dag.getEdgeIds().size());
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionSuccessorFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/neo4j/Neo4jVersionSuccessorFactoryTest.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 
 import edu.berkeley.ground.api.Neo4jTest;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.Neo4jClient.Neo4jConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -19,47 +18,42 @@ public class Neo4jVersionSuccessorFactoryTest extends Neo4jTest {
 
   @Test
   public void testVersionSuccessorCreation() throws GroundException {
-    Neo4jConnection connection = null;
     try {
-      connection = super.neo4jClient.getConnection();
       long fromNodeId = super.factories.getNodeFactory().create("testFromNode", new HashMap<>()).getId();
       long toNodeId = super.factories.getNodeFactory().create("testToNode", new HashMap<>()).getId();
       long fromId = super.createNodeVersion(fromNodeId);
       long toId = super.createNodeVersion(toNodeId);
 
-      long vsId = super.versionSuccessorFactory.create(connection, fromId, toId).getId();
+      long vsId = super.versionSuccessorFactory.create(fromId, toId).getId();
 
-      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, vsId);
+      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(vsId);
 
       assertEquals(fromId, retrieved.getFromId());
       assertEquals(toId, retrieved.getToId());
     } catch (Exception e) {
       fail(e.getMessage());
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testBadVersionSuccessorCreation() throws GroundException {
-    Neo4jConnection connection = null;
     try {
       long toId = -1;
 
       try {
         String nodeName = "testNode";
         long nodeId = super.factories.getNodeFactory().create(nodeName, new HashMap<>()).getId();
-        connection = super.neo4jClient.getConnection();
         toId = super.createNodeVersion(nodeId);
       } catch (GroundException ge) {
         fail(ge.getMessage());
       }
 
       // this statement should be fail because the fromId does not exist
-      super.versionSuccessorFactory.create(connection, 9, toId).getId();
+      super.versionSuccessorFactory.create(9, toId).getId();
     } finally {
-      connection.abort();
+      super.neo4jClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresItemFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresItemFactoryTest.java
@@ -13,7 +13,6 @@ import edu.berkeley.ground.api.versions.GroundType;
 import edu.berkeley.ground.api.versions.Item;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -26,38 +25,34 @@ public class PostgresItemFactoryTest extends PostgresTest {
 
   @Test
   public void testCorrectUpdateWithParent() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
       long testId = 1;
-      connection = super.postgresClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long fromId = 2;
       long toId = 3;
 
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
 
       List<Long> parentIds = new ArrayList<>();
-      super.itemFactory.update(connection, testId, fromId, parentIds);
+      super.itemFactory.update(testId, fromId, parentIds);
 
       parentIds.clear();
       parentIds.add(fromId);
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(2, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> successor = null;
       for (long id : dag.getEdgeIds()) {
-        successor = super.versionSuccessorFactory.retrieveFromDatabase(connection, id);
+        successor = super.versionSuccessorFactory.retrieveFromDatabase(id);
 
-        if (!(successor.getFromId() == 0)) {
+        if (successor.getFromId() != 0) {
           break;
         }
       }
@@ -71,81 +66,74 @@ public class PostgresItemFactoryTest extends PostgresTest {
 
       fail();
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testCorrectUpdateWithoutParent() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
       long testId = 1;
-      connection = super.postgresClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
       long toId = 2;
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(toId);
 
       List<Long> parentIds = new ArrayList<>();
 
       // No parent is specified, and there is no other version in this Item, we should
       // automatically make this a child of EMPTY
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(1, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> successor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(0));
+          dag.getEdgeIds().get(0));
 
       assertEquals(0, successor.getFromId());
       assertEquals(toId, successor.getToId());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testCorrectUpdateWithLinearHistory() throws GroundException {
-    PostgresConnection connection = null;
     try {
       long testId = 1;
-      connection = super.postgresClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long fromId = 2;
       long toId = 3;
 
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
       List<Long> parentIds = new ArrayList<>();
 
       // first, make from a child of EMPTY
-      super.itemFactory.update(connection, testId, fromId, parentIds);
+      super.itemFactory.update(testId, fromId, parentIds);
 
       // then, add to as a child and make sure that it becomes a child of from
       parentIds.clear();
       parentIds.add(fromId);
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(2, dag.getEdgeIds().size());
       assertEquals(toId, (long) dag.getLeaves().get(0));
 
       VersionSuccessor<?> fromSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(0));
+          dag.getEdgeIds().get(0));
 
       VersionSuccessor<?> toSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(1));
+          dag.getEdgeIds().get(1));
 
-      if (!(fromSuccessor.getFromId() == 0)) {
+      if (fromSuccessor.getFromId() != 0) {
         VersionSuccessor<?> tmp = fromSuccessor;
         fromSuccessor = toSuccessor;
         toSuccessor = tmp;
@@ -157,24 +145,21 @@ public class PostgresItemFactoryTest extends PostgresTest {
       assertEquals(fromId, toSuccessor.getFromId());
       assertEquals(toId, toSuccessor.getToId());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testIncorrectUpdate() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
       long testId = 1;
       long fromId = 2;
       long toId = 3;
 
       try {
-        connection = super.postgresClient.getConnection();
-        super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+        super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
-        super.versionFactory.insertIntoDatabase(connection, toId);
+        super.versionFactory.insertIntoDatabase(toId);
       } catch (GroundException ge) {
         fail(ge.getMessage());
       }
@@ -183,58 +168,55 @@ public class PostgresItemFactoryTest extends PostgresTest {
       parentIds.add(fromId);
 
       // this should fail because fromId is not a valid version
-      super.itemFactory.update(connection, testId, toId, parentIds);
+      super.itemFactory.update(testId, toId, parentIds);
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testMultipleParents() throws GroundException {
-    PostgresConnection connection = null;
     try {
       long testId = 1;
-      connection = super.postgresClient.getConnection();
 
-      super.itemFactory.insertIntoDatabase(connection, testId, new HashMap<>());
+      super.itemFactory.insertIntoDatabase(testId, new HashMap<>());
 
       long parentOne = 2;
       long parentTwo = 3;
       long child = 4;
 
-      super.versionFactory.insertIntoDatabase(connection, parentOne);
-      super.versionFactory.insertIntoDatabase(connection, parentTwo);
-      super.versionFactory.insertIntoDatabase(connection, child);
+      super.versionFactory.insertIntoDatabase(parentOne);
+      super.versionFactory.insertIntoDatabase(parentTwo);
+      super.versionFactory.insertIntoDatabase(child);
       List<Long> parentIds = new ArrayList<>();
 
       // first, make the parents children of EMPTY
-      super.itemFactory.update(connection, testId, parentOne, parentIds);
-      super.itemFactory.update(connection, testId, parentTwo, parentIds);
+      super.itemFactory.update(testId, parentOne, parentIds);
+      super.itemFactory.update(testId, parentTwo, parentIds);
 
       // then, add to as a child and make sure that it becomes a child of from
       parentIds.clear();
       parentIds.add(parentOne);
       parentIds.add(parentTwo);
-      super.itemFactory.update(connection, testId, child, parentIds);
+      super.itemFactory.update(testId, child, parentIds);
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(4, dag.getEdgeIds().size());
       assertEquals(child, (long) dag.getLeaves().get(0));
 
       // Retrieve all the version successors and check that they have the correct data.
       VersionSuccessor<?> parentOneSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(0));
+          dag.getEdgeIds().get(0));
 
       VersionSuccessor<?> parentTwoSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(1));
+          dag.getEdgeIds().get(1));
 
       VersionSuccessor<?> childOneSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(2));
+          dag.getEdgeIds().get(2));
 
       VersionSuccessor<?> childTwoSuccessor = super.versionSuccessorFactory.retrieveFromDatabase(
-          connection, dag.getEdgeIds().get(3));
+          dag.getEdgeIds().get(3));
 
       assertEquals(0, parentOneSuccessor.getFromId());
       assertEquals(parentOne, parentOneSuccessor.getToId());
@@ -249,26 +231,23 @@ public class PostgresItemFactoryTest extends PostgresTest {
       assertEquals(child, childTwoSuccessor.getToId());
       assertEquals(child, childTwoSuccessor.getToId());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test
   public void testTags() throws GroundException {
-    PostgresConnection connection = null;
     try {
       long testId = 1;
-      connection = super.postgresClient.getConnection();
       Map<String, Tag> tags = new HashMap<>();
       tags.put("justkey", new Tag(-1, "justkey", null, null));
       tags.put("withintvalue", new Tag(-1, "withintvalue", 1, GroundType.INTEGER));
       tags.put("withstringvalue", new Tag(-1, "withstringvalue", "1", GroundType.STRING));
       tags.put("withboolvalue", new Tag(-1, "withboolvalue", true, GroundType.BOOLEAN));
 
+      super.itemFactory.insertIntoDatabase(testId, tags);
 
-      super.itemFactory.insertIntoDatabase(connection, testId, tags);
-
-      Item retrieved = super.itemFactory.retrieveFromDatabase(connection, testId);
+      Item retrieved = super.itemFactory.retrieveFromDatabase(testId);
 
       assertEquals(testId, retrieved.getId());
       assertEquals(tags.size(), retrieved.getTags().size());
@@ -280,7 +259,7 @@ public class PostgresItemFactoryTest extends PostgresTest {
         assertEquals(retrieved.getId(), retrievedTags.get(key).getId());
       }
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionHistoryDAGFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionHistoryDAGFactoryTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import edu.berkeley.ground.api.PostgresTest;
 import edu.berkeley.ground.api.versions.VersionHistoryDAG;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -17,18 +16,15 @@ public class PostgresVersionHistoryDAGFactoryTest extends PostgresTest {
 
   @Test
   public void testVersionHistoryDAGCreation() throws GroundException {
-    PostgresConnection connection = null;
     try {
       long testId = 1;
       super.versionHistoryDAGFactory.create(testId);
-      connection = super.postgresClient.getConnection();
 
-      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(connection,
-          testId);
+      VersionHistoryDAG<?> dag = super.versionHistoryDAGFactory.retrieveFromDatabase(testId);
 
       assertEquals(0, dag.getEdgeIds().size());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 }

--- a/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionSuccessorFactoryTest.java
+++ b/ground-core/src/test/java/edu/berkeley/ground/api/versions/postgres/PostgresVersionSuccessorFactoryTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import edu.berkeley.ground.api.PostgresTest;
 import edu.berkeley.ground.api.versions.VersionSuccessor;
-import edu.berkeley.ground.db.PostgresClient.PostgresConnection;
 import edu.berkeley.ground.exceptions.GroundException;
 
 import static org.junit.Assert.*;
@@ -17,31 +16,27 @@ public class PostgresVersionSuccessorFactoryTest extends PostgresTest {
 
   @Test
   public void testVersionSuccessorCreation() throws GroundException {
-    PostgresConnection connection = null;
     try {
       long fromId = 1;
       long toId = 2;
 
-      connection = super.postgresClient.getConnection();
-      super.versionFactory.insertIntoDatabase(connection, fromId);
-      super.versionFactory.insertIntoDatabase(connection, toId);
+      super.versionFactory.insertIntoDatabase(fromId);
+      super.versionFactory.insertIntoDatabase(toId);
 
-      VersionSuccessor<?> successor = super.versionSuccessorFactory.create(connection, fromId, toId);
+      VersionSuccessor<?> successor = super.versionSuccessorFactory.create(fromId, toId);
 
-      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(connection,
+      VersionSuccessor<?> retrieved = super.versionSuccessorFactory.retrieveFromDatabase(
           successor.getId());
 
       assertEquals(fromId, retrieved.getFromId());
       assertEquals(toId, retrieved.getToId());
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 
   @Test(expected = GroundException.class)
   public void testBadVersionSuccessorCreation() throws GroundException {
-    PostgresConnection connection = null;
-
     try {
       long fromId = 1;
       long toId = 2;
@@ -49,16 +44,15 @@ public class PostgresVersionSuccessorFactoryTest extends PostgresTest {
       // Catch exceptions for these two lines because they should not fal
       try {
         // the main difference is that we're not creating a Version for the toId
-        connection = super.postgresClient.getConnection();
-        super.versionFactory.insertIntoDatabase(connection, fromId);
+        super.versionFactory.insertIntoDatabase(fromId);
       } catch (GroundException ge) {
         fail(ge.getMessage());
       }
 
       // This statement should fail because toId is not in the database
-      super.versionSuccessorFactory.create(connection, fromId, toId);
+      super.versionSuccessorFactory.create(fromId, toId);
     } finally {
-      connection.abort();
+      super.postgresClient.abort();
     }
   }
 }

--- a/plugins/hive-plugin/src/main/java/edu/berkeley/ground/plugins/hive/GroundReadWrite.java
+++ b/plugins/hive-plugin/src/main/java/edu/berkeley/ground/plugins/hive/GroundReadWrite.java
@@ -27,7 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 import edu.berkeley.ground.api.models.*;
 import edu.berkeley.ground.api.models.postgres.*;
 import edu.berkeley.ground.db.DBClient;
-import edu.berkeley.ground.db.DBClient.GroundDBConnection;
 import edu.berkeley.ground.db.Neo4jClient;
 import edu.berkeley.ground.db.PostgresClient;
 import edu.berkeley.ground.exceptions.GroundDBException;

--- a/plugins/hive-plugin/src/main/java/edu/berkeley/ground/plugins/hive/GroundReadWrite.java
+++ b/plugins/hive-plugin/src/main/java/edu/berkeley/ground/plugins/hive/GroundReadWrite.java
@@ -62,10 +62,8 @@ public class GroundReadWrite {
   final static String TEST_CONN = "test_connection";
 
   protected static final String DEFAULT_FACTORY = "neo4j";
-  private static GroundDBConnection testConn;
 
   private static Configuration staticConf = null;
-  private GroundDBConnection conn;
 
   private NodeFactory nodeFactory;
 
@@ -169,7 +167,6 @@ public class GroundReadWrite {
       password = props.getProperty("edu.berkeley.ground.model.config.password");
       LOG.info("client cass is " + clientClass);
       if (TEST_CONN.equals(clientClass)) {
-        setConn(testConn);
         factoryType = props.getProperty("edu.berkeley.ground.model.config.factoryType");
         LOG.info("Using test connection."); // for unit and integration test
         if (factoryType.contains("neo4j")) {
@@ -225,30 +222,15 @@ public class GroundReadWrite {
     this.structureVersionFactory = postgresFactories.getStructureVersionFactory();
   }
 
-  /**
-   * Use this for unit testing only, so that a mock connection object can be
-   * passed in.
-   *
-   * @param connection Mock connection objecct
-   */
-  @VisibleForTesting
-  static void setTestConnection(GroundDBConnection connection) {
-    testConn = connection;
-  }
-
   public void close() throws IOException {
   }
 
   public void begin() {
-    try {
-      dbClient.getConnection();
-    } catch (GroundDBException e) {
-    }
   }
 
   public void commit() {
     try {
-      dbClient.getConnection().commit();
+      dbClient.commit();
     } catch (GroundDBException e) {
       throw new RuntimeException(e);
     }
@@ -270,12 +252,8 @@ public class GroundReadWrite {
     return factoryType;
   }
 
-  public GroundDBConnection getConn() {
-    return conn;
-  }
-
-  public void setConn(GroundDBConnection conn) {
-    this.conn = conn;
+  public DBClient getDbClient() {
+    return dbClient;
   }
 
   public NodeFactory getNodeFactory() {


### PR DESCRIPTION
This PR is broken up into two commits: one part with just a file-level reformat, and the other with the real changes. I'm not quite happy with how connections are being closed at the moment; I'm hoping to use [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to properly clean them up.