### PR TITLE
README: Revert the Coveralls badge to an SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ground
 
 [![Build Status](https://amplab.cs.berkeley.edu/jenkins/buildStatus/icon?job=Ground)](https://amplab.cs.berkeley.edu/jenkins/job/Ground/)
-[![Coverage Status](https://coveralls.io/repos/github/ground-context/ground/badge.png?branch=master)](https://coveralls.io/github/ground-context/ground?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/ground-context/ground/badge.svg?branch=master)](https://coveralls.io/github/ground-context/ground?branch=master)
 
 Ground is an open-source data context service under development in UC Berkeley's [RISE Lab](http://rise.cs.berkeley.edu). Ground serves as a central model, API, and repistory for capturing the broad context in which data is used. Our goal is to address practical problems for the Big Data community in the short term and to open up opportunities for long-term research and innovation.
 


### PR DESCRIPTION
The Jenkins badge *is* an SVG; it's just not flat. Also, the PNG looks noticeably worse. Once Jenkins gets upgraded, [the changes to make the badges flat](https://issues.jenkins-ci.org/browse/JENKINS-26705) should be present, which will make our badges look consistent.