### PR TITLE
api: Use source keys

### DIFF
--- a/scripts/cassandra/cassandra.cql
+++ b/scripts/cassandra/cassandra.cql
@@ -48,7 +48,7 @@ create table structure (
     item_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table structure_version (
@@ -90,21 +90,21 @@ create table edge (
     from_node_id bigint,
     to_node_id bigint,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table node (
     item_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table graph (
     item_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table node_version (
@@ -138,14 +138,14 @@ create table principal (
     node_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (node_id, name)
+    PRIMARY KEY (node_id, source_key)
 );
 
 create table lineage_edge (
     item_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table lineage_edge_version (
@@ -160,7 +160,7 @@ create table lineage_graph (
     item_id bigint,
     source_key varchar,
     name varchar,
-    PRIMARY KEY (item_id, name)
+    PRIMARY KEY (item_id, source_key)
 );
 
 create table lineage_graph_version (

--- a/src/main/java/edu/berkeley/ground/dao/models/EdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/EdgeFactory.java
@@ -29,7 +29,7 @@ public abstract class EdgeFactory {
                               long toNodeId,
                               Map<String, Tag> tags) throws GroundException;
 
-  public abstract Edge retrieveFromDatabase(String name) throws GroundException;
+  public abstract Edge retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract Edge retrieveFromDatabase(long id) throws GroundException;
 

--- a/src/main/java/edu/berkeley/ground/dao/models/GraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/GraphFactory.java
@@ -26,7 +26,7 @@ public abstract class GraphFactory {
                                String sourceKey,
                                Map<String, Tag> tags) throws GroundException;
 
-  public abstract Graph retrieveFromDatabase(String name) throws GroundException;
+  public abstract Graph retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract void update(long itemId, long childId, List<Long> parentIds)
       throws GroundException;

--- a/src/main/java/edu/berkeley/ground/dao/models/NodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/NodeFactory.java
@@ -27,14 +27,14 @@ public abstract class NodeFactory {
                               Map<String, Tag> tags)
       throws GroundException;
 
-  public abstract Node retrieveFromDatabase(String name) throws GroundException;
+  public abstract Node retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract void update(long itemId, long childId, List<Long> parentIds)
       throws GroundException;
 
   public abstract void truncate(long itemId, int numLevels) throws GroundException;
 
-  public abstract List<Long> getLeaves(String name) throws GroundException;
+  public abstract List<Long> getLeaves(String sourceKey) throws GroundException;
 
   protected static Node construct(long id, String name, String sourceKey, Map<String, Tag> tags) {
     return new Node(id, name, sourceKey, tags);

--- a/src/main/java/edu/berkeley/ground/dao/models/StructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/StructureFactory.java
@@ -27,7 +27,7 @@ public abstract class StructureFactory {
                                    Map<String, Tag> tags)
       throws GroundException;
 
-  public abstract Structure retrieveFromDatabase(String name) throws GroundException;
+  public abstract Structure retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract void update(long itemId, long childId, List<Long> parentIds)
       throws GroundException;

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactory.java
@@ -88,6 +88,20 @@ public class CassandraEdgeFactory extends EdgeFactory {
                      long fromNodeId,
                      long toNodeId,
                      Map<String, Tag> tags) throws GroundException {
+
+    Edge edge = null;
+    try {
+      edge = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Edge found")) {
+        throw e;
+      }
+    }
+
+    if (edge != null) {
+      throw new GroundException("Edge with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactory.java
@@ -106,8 +106,8 @@ public class CassandraEdgeFactory extends EdgeFactory {
   }
 
   @Override
-  public Edge retrieveFromDatabase(String name) throws GroundException {
-    return this.retrieveByPredicate("name", name, GroundType.STRING);
+  public Edge retrieveFromDatabase(String sourceKey) throws GroundException {
+    return this.retrieveByPredicate("source_key", sourceKey, GroundType.STRING);
   }
 
   @Override

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactory.java
@@ -87,27 +87,28 @@ public class CassandraGraphFactory extends GraphFactory {
   /**
    * Retrieves an edge from the database.
    *
-   * @param name the name of the graph to retrieve
+   * @param sourceKey the key of the graph to retrieve
    * @return the retrieved graph
    * @throws GroundException either the graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public Graph retrieveFromDatabase(String name) throws GroundException {
+  public Graph retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     CassandraResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("graph", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Graph found with name " + name + ".");
+      throw new GroundException("No Graph found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong("item_id");
-    String sourceKey = resultSet.getString("source_key");
+    String name = resultSet.getString("name");
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
-    LOGGER.info("Retrieved graph " + name + ".");
+
+    LOGGER.info("Retrieved graph " + sourceKey + ".");
 
     return GraphFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactory.java
@@ -68,6 +68,19 @@ public class CassandraGraphFactory extends GraphFactory {
    */
   @Override
   public Graph create(String name, String sourceKey, Map<String, Tag> tags) throws GroundException {
+    Graph graph = null;
+    try {
+      graph = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Graph found")) {
+        throw e;
+      }
+    }
+
+    if (graph != null) {
+      throw new GroundException("Graph with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);
@@ -85,7 +98,7 @@ public class CassandraGraphFactory extends GraphFactory {
   }
 
   /**
-   * Retrieves an edge from the database.
+   * Retrieves a graph from the database.
    *
    * @param sourceKey the key of the graph to retrieve
    * @return the retrieved graph

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactory.java
@@ -86,13 +86,13 @@ public class CassandraNodeFactory extends NodeFactory {
   /**
    * Retrieve the DAG leaves for this node.
    *
-   * @param name the name of the node to retrieve leaves for.
+   * @param sourceKey the key of the node to retrieve leaves for.
    * @return the leaves of the node
    * @throws GroundException an error while retrieving the node
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Node node = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Node node = this.retrieveFromDatabase(sourceKey);
     List<Long> leaves = this.itemFactory.getLeaves(node.getId());
 
     return leaves;
@@ -101,28 +101,28 @@ public class CassandraNodeFactory extends NodeFactory {
   /**
    * Retrieve a node from the database.
    *
-   * @param name the name of the node to retrieve
+   * @param sourceKey the key of the node to retrieve
    * @return the retrieved node
    * @throws GroundException either the node doesn't exist or couldn't be retrieved
    */
   @Override
-  public Node retrieveFromDatabase(String name) throws GroundException {
+  public Node retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     CassandraResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("node", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Node found with name " + name + ".");
+      throw new GroundException("No Node found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong("item_id");
-    String sourceKey = resultSet.getString("source_key");
+    String name = resultSet.getString("name");
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved node " + name + ".");
+    LOGGER.info("Retrieved node " + sourceKey + ".");
     return NodeFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactory.java
@@ -68,6 +68,19 @@ public class CassandraNodeFactory extends NodeFactory {
    */
   @Override
   public Node create(String name, String sourceKey, Map<String, Tag> tags) throws GroundException {
+    Node node = null;
+    try {
+      node = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Node found")) {
+        throw e;
+      }
+    }
+
+    if (node != null) {
+      throw new GroundException("Node with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactory.java
@@ -69,6 +69,19 @@ public class CassandraStructureFactory extends StructureFactory {
   @Override
   public Structure create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
+    Structure structure = null;
+    try {
+      structure = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Structure found")) {
+        throw e;
+      }
+    }
+
+    if (structure != null) {
+      throw new GroundException("Structure with source_key " + sourceKey + " already exists.");
+    }
+
 
     long uniqueId = this.idGenerator.generateItemId();
 

--- a/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactory.java
@@ -88,13 +88,13 @@ public class CassandraStructureFactory extends StructureFactory {
   /**
    * Retrieve the leaves of this structure's DAG.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the list of leaves in this structure's DAG
    * @throws GroundException an error while retrieving the structure
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Structure structure = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Structure structure = this.retrieveFromDatabase(sourceKey);
 
     List<Long> leaves = this.itemFactory.getLeaves(structure.getId());
     return leaves;
@@ -103,28 +103,28 @@ public class CassandraStructureFactory extends StructureFactory {
   /**
    * Retrieve a structure from the database.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the retrieved structure
    * @throws GroundException either the structure doesn't exist or couldn't be retrieved
    */
   @Override
-  public Structure retrieveFromDatabase(String name) throws GroundException {
+  public Structure retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     CassandraResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("structure", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Structure found with name " + name + ".");
+      throw new GroundException("No Structure found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong("item_id");
-    String sourceKey = resultSet.getString("source_key");
+    String name = resultSet.getString("name");
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved structure " + name + ".");
+    LOGGER.info("Retrieved structure " + sourceKey + ".");
     return StructureFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactory.java
@@ -88,6 +88,18 @@ public class Neo4jEdgeFactory extends EdgeFactory {
                      long toNodeId,
                      Map<String, Tag> tags) throws GroundException {
 
+    Edge edge = null;
+    try {
+      edge = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Edge found")) {
+        throw e;
+      }
+    }
+
+    if (edge != null) {
+      throw new GroundException("Edge with source_key " + sourceKey + " already exists.");
+    }
 
     long uniqueId = idGenerator.generateItemId();
 

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactory.java
@@ -87,6 +87,8 @@ public class Neo4jEdgeFactory extends EdgeFactory {
                      long fromNodeId,
                      long toNodeId,
                      Map<String, Tag> tags) throws GroundException {
+
+
     long uniqueId = idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);
@@ -105,8 +107,8 @@ public class Neo4jEdgeFactory extends EdgeFactory {
   }
 
   @Override
-  public Edge retrieveFromDatabase(String name) throws GroundException {
-    return this.retrieveByPredicate("name", name, GroundType.STRING);
+  public Edge retrieveFromDatabase(String sourceKey) throws GroundException {
+    return this.retrieveByPredicate("source_key", sourceKey, GroundType.STRING);
   }
 
   @Override

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactory.java
@@ -86,28 +86,28 @@ public class Neo4jGraphFactory extends GraphFactory {
   /**
    * Retrieves an edge from the database.
    *
-   * @param name the name of the graph to retrieve
+   * @param sourceKey the key of the graph to retrieve
    * @return the retrieved graph
    * @throws GroundException either the graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public Graph retrieveFromDatabase(String name) throws GroundException {
+  public Graph retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     Record record;
     try {
       record = this.dbClient.getVertex(predicates);
     } catch (EmptyResultException e) {
-      throw new GroundDbException("No Graph found with name " + name + ".");
+      throw new GroundDbException("No Graph found with source_key " + sourceKey + ".");
     }
 
     long id = record.get("v").asNode().get("id").asLong();
-    String sourceKey = record.get("v").asNode().get("source_key").asString();
+    String name = record.get("v").asNode().get("name").asString();
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved graph " + name + ".");
+    LOGGER.info("Retrieved graph " + sourceKey + ".");
 
     return GraphFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactory.java
@@ -68,6 +68,19 @@ public class Neo4jGraphFactory extends GraphFactory {
    */
   @Override
   public Graph create(String name, String sourceKey, Map<String, Tag> tags) throws GroundException {
+    Graph graph = null;
+    try {
+      graph = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Graph found")) {
+        throw e;
+      }
+    }
+
+    if (graph != null) {
+      throw new GroundException("Graph with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     List<DbDataContainer> insertions = new ArrayList<>();
@@ -84,7 +97,7 @@ public class Neo4jGraphFactory extends GraphFactory {
   }
 
   /**
-   * Retrieves an edge from the database.
+   * Retrieves a graph from the database.
    *
    * @param sourceKey the key of the graph to retrieve
    * @return the retrieved graph

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactory.java
@@ -67,6 +67,19 @@ public class Neo4jNodeFactory extends NodeFactory {
    */
   @Override
   public Node create(String name, String sourceKey, Map<String, Tag> tags) throws GroundException {
+    Node node = null;
+    try {
+      node = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Node found")) {
+        throw e;
+      }
+    }
+
+    if (node != null) {
+      throw new GroundException("Node with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     List<DbDataContainer> insertions = new ArrayList<>();

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactory.java
@@ -85,13 +85,13 @@ public class Neo4jNodeFactory extends NodeFactory {
   /**
    * Retrieve the DAG leaves for this node.
    *
-   * @param name the name of the node to retrieve leaves for.
+   * @param sourceKey the key of the node to retrieve leaves for.
    * @return the leaves of the node
    * @throws GroundException an error while retrieving the node
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Node node = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Node node = this.retrieveFromDatabase(sourceKey);
     List<Long> leaves = this.itemFactory.getLeaves(node.getId());
 
     return leaves;
@@ -100,28 +100,28 @@ public class Neo4jNodeFactory extends NodeFactory {
   /**
    * Retrieve a node from the database.
    *
-   * @param name the name of the node to retrieve
+   * @param sourceKey the key of the node to retrieve
    * @return the retrieved node
    * @throws GroundException either the node doesn't exist or couldn't be retrieved
    */
   @Override
-  public Node retrieveFromDatabase(String name) throws GroundException {
+  public Node retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     Record record;
     try {
       record = this.dbClient.getVertex("Node", predicates);
     } catch (EmptyResultException e) {
-      throw new GroundDbException("No Node found with name " + name + ".");
+      throw new GroundDbException("No Node found with source_key " + sourceKey + ".");
     }
 
     long id = record.get("v").asNode().get("id").asLong();
-    String sourceKey = record.get("v").asNode().get("source_key").asString();
+    String name = record.get("v").asNode().get("name").asString();
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved node " + name + ".");
+    LOGGER.info("Retrieved node " + sourceKey + ".");
 
     return NodeFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactory.java
@@ -86,13 +86,13 @@ public class Neo4jStructureFactory extends StructureFactory {
   /**
    * Retrieve the leaves of this structure's DAG.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the list of leaves in this structure's DAG
    * @throws GroundException an error while retrieving the structure
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Structure structure = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Structure structure = this.retrieveFromDatabase(sourceKey);
     List<Long> leaves = this.itemFactory.getLeaves(structure.getId());
 
     return leaves;
@@ -101,28 +101,28 @@ public class Neo4jStructureFactory extends StructureFactory {
   /**
    * Retrieve a structure from the database.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the retrieved structure
    * @throws GroundException either the structure doesn't exist or couldn't be retrieved
    */
   @Override
-  public Structure retrieveFromDatabase(String name) throws GroundException {
+  public Structure retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     Record record;
     try {
       record = this.dbClient.getVertex("Structure", predicates);
     } catch (EmptyResultException e) {
-      throw new GroundDbException("No Structure found with name " + name + ".");
+      throw new GroundDbException("No Structure found with source_key " + sourceKey + ".");
     }
 
     long id = record.get("v").asNode().get("id").asLong();
-    String sourceKey = record.get("v").asNode().get("source_key").asString();
+    String name = record.get("v").asNode().get("name").asString();
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved structure " + name + ".");
+    LOGGER.info("Retrieved structure " + sourceKey + ".");
 
     return StructureFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactory.java
@@ -68,6 +68,20 @@ public class Neo4jStructureFactory extends StructureFactory {
   @Override
   public Structure create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
+
+    Structure structure = null;
+    try {
+      structure = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No Structure found")) {
+        throw e;
+      }
+    }
+
+    if (structure != null) {
+      throw new GroundException("Structure with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     List<DbDataContainer> insertions = new ArrayList<>();

--- a/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresEdgeFactory.java
@@ -106,8 +106,8 @@ public class PostgresEdgeFactory extends EdgeFactory {
   }
 
   @Override
-  public Edge retrieveFromDatabase(String name) throws GroundException {
-    return this.retrieveByPredicate("name", name, GroundType.STRING);
+  public Edge retrieveFromDatabase(String sourceKey) throws GroundException {
+    return this.retrieveByPredicate("source_key", sourceKey, GroundType.STRING);
   }
 
   @Override

--- a/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactory.java
@@ -85,28 +85,28 @@ public class PostgresGraphFactory extends GraphFactory {
   /**
    * Retrieves an edge from the database.
    *
-   * @param name the name of the graph to retrieve
+   * @param sourceKey the sourceKey of the graph to retrieve
    * @return the retrieved graph
    * @throws GroundException either the graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public Graph retrieveFromDatabase(String name) throws GroundException {
+  public Graph retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     PostgresResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("graph", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Graph found with name " + name + ".");
+      throw new GroundException("No Graph found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong(1);
-    String sourceKey = resultSet.getString(2);
+    String name = resultSet.getString(3);
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved graph " + name + ".");
+    LOGGER.info("Retrieved graph " + sourceKey + ".");
 
     return GraphFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactory.java
@@ -85,13 +85,13 @@ public class PostgresNodeFactory extends NodeFactory {
   /**
    * Retrieve the DAG leaves for this node.
    *
-   * @param name the name of the node to retrieve leaves for.
+   * @param sourceKey the key of the node to retrieve leaves for.
    * @return the leaves of the node
    * @throws GroundException an error while retrieving the node
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Node node = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Node node = this.retrieveFromDatabase(sourceKey);
     List<Long> leaves = this.itemFactory.getLeaves(node.getId());
 
     return leaves;
@@ -101,28 +101,29 @@ public class PostgresNodeFactory extends NodeFactory {
   /**
    * Retrieve a node from the database.
    *
-   * @param name the name of the node to retrieve
+   * @param sourceKey the key of the node to retrieve
    * @return the retrieved node
    * @throws GroundException either the node doesn't exist or couldn't be retrieved
    */
   @Override
-  public Node retrieveFromDatabase(String name) throws GroundException {
+  public Node retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     PostgresResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("node", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Node found with name " + name + ".");
+      throw new GroundException("No Node found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong(1);
-    String sourceKey = resultSet.getString(2);
+    String name = resultSet.getString(3);
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved node " + name + ".");
+    LOGGER.info("Retrieved node " + sourceKey + ".");
+
     return NodeFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactory.java
@@ -86,13 +86,13 @@ public class PostgresStructureFactory extends StructureFactory {
   /**
    * Retrieve the leaves of this structure's DAG.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the list of leaves in this structure's DAG
    * @throws GroundException an error while retrieving the structure
    */
   @Override
-  public List<Long> getLeaves(String name) throws GroundException {
-    Structure structure = this.retrieveFromDatabase(name);
+  public List<Long> getLeaves(String sourceKey) throws GroundException {
+    Structure structure = this.retrieveFromDatabase(sourceKey);
     List<Long> leaves = this.itemFactory.getLeaves(structure.getId());
 
     return leaves;
@@ -101,28 +101,28 @@ public class PostgresStructureFactory extends StructureFactory {
   /**
    * Retrieve a structure from the database.
    *
-   * @param name the name of the structure
+   * @param sourceKey the key of the structure
    * @return the retrieved structure
    * @throws GroundException either the structure doesn't exist or couldn't be retrieved
    */
   @Override
-  public Structure retrieveFromDatabase(String name) throws GroundException {
+  public Structure retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     PostgresResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("structure", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No Structure found with name " + name + ".");
+      throw new GroundException("No Structure found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong(1);
-    String sourceKey = resultSet.getString(2);
+    String name = resultSet.getString(3);
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved structure " + name + ".");
+    LOGGER.info("Retrieved structure " + sourceKey + ".");
     return StructureFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/usage/LineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/LineageEdgeFactory.java
@@ -27,7 +27,7 @@ public abstract class LineageEdgeFactory {
                                      Map<String, Tag> tags)
       throws GroundException;
 
-  public abstract LineageEdge retrieveFromDatabase(String name) throws GroundException;
+  public abstract LineageEdge retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract void update(long itemId, long childId, List<Long> parentIds)
       throws GroundException;

--- a/src/main/java/edu/berkeley/ground/dao/usage/LineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/LineageGraphFactory.java
@@ -27,7 +27,7 @@ public abstract class LineageGraphFactory {
                                       Map<String, Tag> tags)
       throws GroundException;
 
-  public abstract LineageGraph retrieveFromDatabase(String name) throws GroundException;
+  public abstract LineageGraph retrieveFromDatabase(String sourceKey) throws GroundException;
 
   public abstract void update(long itemId, long childId, List<Long> parentIds)
       throws GroundException;

--- a/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactory.java
@@ -87,28 +87,28 @@ public class CassandraLineageEdgeFactory extends LineageEdgeFactory {
   /**
    * Retrieve a lineage edge from the database.
    *
-   * @param name the name of the lineage edge
+   * @param sourceKey the key of the lineage edge
    * @return the retrieved lineage edge
    * @throws GroundException either the lineage edge doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
+  public LineageEdge retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     CassandraResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("lineage_edge", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No LineageEdge found with name " + name + ".");
+      throw new GroundException("No LineageEdge found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong("item_id");
-    String sourceKey = resultSet.getString("source_key");
+    String name = resultSet.getString("name");
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage edge " + name + ".");
+    LOGGER.info("Retrieved lineage edge " + sourceKey + ".");
     return LineageEdgeFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactory.java
@@ -69,6 +69,20 @@ public class CassandraLineageEdgeFactory extends LineageEdgeFactory {
   public LineageEdge create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
 
+    LineageEdge lineageEdge = null;
+    try {
+      lineageEdge = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No LineageEdge found")) {
+        throw e;
+      }
+    }
+
+    if (lineageEdge != null) {
+      throw new GroundException("LineageEdge with source_key " + sourceKey + " already exists.");
+    }
+
+
     long uniqueId = this.idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);

--- a/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactory.java
@@ -87,29 +87,29 @@ public class CassandraLineageGraphFactory extends LineageGraphFactory {
   /**
    * Retrieve a lineage graph from the database.
    *
-   * @param name the name of the lineage graph
+   * @param sourceKey the key of the lineage graph
    * @return the retrieved lineage graph
    * @throws GroundException either the lineage graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageGraph retrieveFromDatabase(String name) throws GroundException {
+  public LineageGraph retrieveFromDatabase(String sourceKey) throws GroundException {
 
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     CassandraResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("lineage_graph", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No LineageGraph found with name " + name + ".");
+      throw new GroundException("No LineageGraph found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong("item_id");
-    String sourceKey = resultSet.getString("source_key");
+    String name = resultSet.getString("name");
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage_graph " + name + ".");
+    LOGGER.info("Retrieved lineage_graph " + sourceKey + ".");
     return LineageGraphFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactory.java
@@ -69,6 +69,19 @@ public class CassandraLineageGraphFactory extends LineageGraphFactory {
   public LineageGraph create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
 
+    LineageGraph lineageGraph = null;
+    try {
+      lineageGraph = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No LineageGraph found")) {
+        throw e;
+      }
+    }
+
+    if (lineageGraph != null) {
+      throw new GroundException("LineageGraph with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     this.itemFactory.insertIntoDatabase(uniqueId, tags);

--- a/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactory.java
@@ -67,8 +67,20 @@ public class Neo4jLineageEdgeFactory extends LineageEdgeFactory {
   @Override
   public LineageEdge create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
-    long uniqueId = this.idGenerator.generateItemId();
+    LineageEdge lineageEdge = null;
+    try {
+      lineageEdge = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No LineageEdge found")) {
+        throw e;
+      }
+    }
 
+    if (lineageEdge != null) {
+      throw new GroundException("LineageEdge with source_key " + sourceKey + " already exists.");
+    }
+
+    long uniqueId = this.idGenerator.generateItemId();
 
     List<DbDataContainer> insertions = new ArrayList<>();
     insertions.add(new DbDataContainer("name", GroundType.STRING, name));

--- a/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactory.java
@@ -85,28 +85,28 @@ public class Neo4jLineageEdgeFactory extends LineageEdgeFactory {
   /**
    * Retrieve a lineage edge from the database.
    *
-   * @param name the name of the lineage edge
+   * @param sourceKey the key of the lineage edge
    * @return the retrieved lineage edge
    * @throws GroundException either the lineage edge doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
+  public LineageEdge retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     Record record;
     try {
       record = this.dbClient.getVertex(predicates);
     } catch (EmptyResultException e) {
-      throw new GroundDbException("No LineageEdge found with name " + name + ".");
+      throw new GroundDbException("No LineageEdge found with source_key " + sourceKey + ".");
     }
 
     long id = record.get("v").asNode().get("id").asLong();
-    String sourceKey = record.get("v").asNode().get("source_key").asString();
+    String name = record.get("v").asNode().get("name").asString();
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage edge " + name + ".");
+    LOGGER.info("Retrieved lineage edge " + sourceKey + ".");
     return LineageEdgeFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactory.java
@@ -70,6 +70,19 @@ public class Neo4jLineageGraphFactory extends LineageGraphFactory {
   public LineageGraph create(String name, String sourceKey, Map<String, Tag> tags)
       throws GroundException {
 
+    LineageGraph lineageGraph = null;
+    try {
+      lineageGraph = this.retrieveFromDatabase(sourceKey);
+    } catch (GroundException e) {
+      if (!e.getMessage().contains("No LineageGraph found")) {
+        throw e;
+      }
+    }
+
+    if (lineageGraph != null) {
+      throw new GroundException("LineageGraph with source_key " + sourceKey + " already exists.");
+    }
+
     long uniqueId = this.idGenerator.generateItemId();
 
     List<DbDataContainer> insertions = new ArrayList<>();

--- a/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactory.java
@@ -88,28 +88,28 @@ public class Neo4jLineageGraphFactory extends LineageGraphFactory {
   /**
    * Retrieve a lineage graph from the database.
    *
-   * @param name the name of the lineage graph
+   * @param sourceKey the key of the lineage graph
    * @return the retrieved lineage graph
    * @throws GroundException either the lineage graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageGraph retrieveFromDatabase(String name) throws GroundException {
+  public LineageGraph retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     Record record;
     try {
       record = this.dbClient.getVertex(predicates);
     } catch (EmptyResultException e) {
-      throw new GroundDbException("No LineageGraph found with name " + name + ".");
+      throw new GroundDbException("No LineageGraph found with source_key " + sourceKey + ".");
     }
 
     long id = record.get("v").asNode().get("id").asLong();
-    String sourceKey = record.get("v").asNode().get("source_key").asString();
+    String name = record.get("v").asNode().get("name").asString();
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage graph " + name + ".");
+    LOGGER.info("Retrieved lineage graph " + sourceKey + ".");
 
     return LineageGraphFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactory.java
@@ -87,28 +87,28 @@ public class PostgresLineageEdgeFactory extends LineageEdgeFactory {
   /**
    * Retrieve a lineage edge from the database.
    *
-   * @param name the name of the lineage edge
+   * @param sourceKey the key of the lineage edge
    * @return the retrieved lineage edge
    * @throws GroundException either the lineage edge doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageEdge retrieveFromDatabase(String name) throws GroundException {
+  public LineageEdge retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     PostgresResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("lineage_edge", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No LineageEdge found with name " + name + ".");
+      throw new GroundException("No LineageEdge found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong(1);
-    String sourceKey = resultSet.getString(2);
+    String name = resultSet.getString(3);
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage edge " + name + ".");
+    LOGGER.info("Retrieved lineage edge " + sourceKey + ".");
     return LineageEdgeFactory.construct(id, name, sourceKey, tags);
   }
 

--- a/src/main/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactory.java
+++ b/src/main/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactory.java
@@ -87,28 +87,28 @@ public class PostgresLineageGraphFactory extends LineageGraphFactory {
   /**
    * Retrieve a lineage graph from the database.
    *
-   * @param name the name of the lineage graph
+   * @param sourceKey the key of the lineage graph
    * @return the retrieved lineage graph
    * @throws GroundException either the lineage graph doesn't exist or couldn't be retrieved
    */
   @Override
-  public LineageGraph retrieveFromDatabase(String name) throws GroundException {
+  public LineageGraph retrieveFromDatabase(String sourceKey) throws GroundException {
     List<DbDataContainer> predicates = new ArrayList<>();
-    predicates.add(new DbDataContainer("name", GroundType.STRING, name));
+    predicates.add(new DbDataContainer("source_key", GroundType.STRING, sourceKey));
 
     PostgresResults resultSet;
     try {
       resultSet = this.dbClient.equalitySelect("lineage_graph", DbClient.SELECT_STAR, predicates);
     } catch (EmptyResultException e) {
-      throw new GroundException("No LineageGraph found with name " + name + ".");
+      throw new GroundException("No LineageGraph found with source_key " + sourceKey + ".");
     }
 
     long id = resultSet.getLong(1);
-    String sourceKey = resultSet.getString(2);
+    String name = resultSet.getString(3);
 
     Map<String, Tag> tags = this.itemFactory.retrieveFromDatabase(id).getTags();
 
-    LOGGER.info("Retrieved lineage_graph " + name + ".");
+    LOGGER.info("Retrieved lineage_graph " + sourceKey + ".");
 
     return LineageGraphFactory.construct(id, name, sourceKey, tags);
   }

--- a/src/main/java/edu/berkeley/ground/db/PostgresClient.java
+++ b/src/main/java/edu/berkeley/ground/db/PostgresClient.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.postgresql.PGStatement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,6 +270,7 @@ public class PostgresClient extends DbClient {
       // Otherwise, prepare the statement, then cache it.
       PreparedStatement newStatement = this.connection.prepareStatement(sql);
       this.preparedStatements.put(sql, newStatement);
+      ((PGStatement) newStatement).setPrepareThreshold(10);
       return newStatement;
     } catch (SQLException e) {
       throw new GroundDbException(e);

--- a/src/main/java/edu/berkeley/ground/resources/EdgesResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/EdgesResource.java
@@ -77,11 +77,11 @@ public class EdgesResource {
   @GET
   @Timed
   @ApiOperation(value = "Get an edge")
-  @Path("/{name}/{key}")
-  public Edge getEdge(@PathParam("name") String name) throws GroundException {
+  @Path("/{sourceKey}/{key}")
+  public Edge getEdge(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving edge " + name + ".");
-      return this.edgeFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving edge " + sourceKey + ".");
+      return this.edgeFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }
@@ -193,20 +193,20 @@ public class EdgesResource {
   /**
    * Truncate an edge's history to be of a certain height, only keeping the most recent levels.
    *
-   * @param name the name of the edge to truncate
+   * @param sourceKey the name of the edge to truncate
    * @param height the number of levels to keep
    * @throws GroundException an error while truncating this edge
    */
   @POST
   @Timed
-  @Path("/truncate/{name}/{height}")
-  public void truncateEdge(@PathParam("name") String name, @PathParam("height") int height)
+  @Path("/truncate/{sourceKey}/{height}")
+  public void truncateEdge(@PathParam("sourceKey") String sourceKey, @PathParam("height") int height)
       throws GroundException {
 
     try {
-      LOGGER.info("Truncating edge " + name + " to height " + height + ".");
+      LOGGER.info("Truncating edge " + sourceKey + " to height " + height + ".");
 
-      long id = this.edgeFactory.retrieveFromDatabase(name).getId();
+      long id = this.edgeFactory.retrieveFromDatabase(sourceKey).getId();
       this.edgeFactory.truncate(id, height);
       this.dbClient.commit();
 

--- a/src/main/java/edu/berkeley/ground/resources/GraphsResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/GraphsResource.java
@@ -61,11 +61,11 @@ public class GraphsResource {
 
   @GET
   @Timed
-  @Path("/{name}")
-  public Graph getGraph(@PathParam("name") String name) throws GroundException {
+  @Path("/{sourceKey}")
+  public Graph getGraph(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving graph " + name + ".");
-      return this.graphFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving graph " + sourceKey + ".");
+      return this.graphFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }

--- a/src/main/java/edu/berkeley/ground/resources/LineageEdgesResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/LineageEdgesResource.java
@@ -61,10 +61,11 @@ public class LineageEdgesResource {
   @GET
   @Timed
   @Path("/{name}")
-  public LineageEdge getLineageEdge(@PathParam("name") String name) throws GroundException {
+  public LineageEdge getLineageEdge(@PathParam("sourceKey") String sourceKey)
+      throws GroundException {
     try {
-      LOGGER.info("Retrieving lineage edge " + name + ".");
-      return this.lineageEdgeFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving lineage edge " + sourceKey + ".");
+      return this.lineageEdgeFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }

--- a/src/main/java/edu/berkeley/ground/resources/LineageGraphsResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/LineageGraphsResource.java
@@ -63,10 +63,11 @@ public class LineageGraphsResource {
   @GET
   @Timed
   @Path("/{name}")
-  public LineageGraph getLineageGraph(@PathParam("name") String name) throws GroundException {
+  public LineageGraph getLineageGraph(@PathParam("sourceKey") String sourceKey)
+      throws GroundException {
     try {
-      LOGGER.info("Retrieving graph " + name + ".");
-      return this.lineageGraphFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving graph " + sourceKey + ".");
+      return this.lineageGraphFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }

--- a/src/main/java/edu/berkeley/ground/resources/NodesResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/NodesResource.java
@@ -64,10 +64,10 @@ public class NodesResource {
   @GET
   @Timed
   @Path("/{name}")
-  public Node getNode(@PathParam("name") String name) throws GroundException {
+  public Node getNode(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving node " + name + ".");
-      return this.nodeFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving node " + sourceKey + ".");
+      return this.nodeFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }
@@ -87,11 +87,11 @@ public class NodesResource {
 
   @GET
   @Timed
-  @Path("/{name}/latest")
-  public List<Long> getLatestVersions(@PathParam("name") String name) throws GroundException {
+  @Path("/{sourceKey}/latest")
+  public List<Long> getLatestVersions(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving the latest version of node " + name + ".");
-      return this.nodeFactory.getLeaves(name);
+      LOGGER.info("Retrieving the latest version of node " + sourceKey + ".");
+      return this.nodeFactory.getLeaves(sourceKey);
     } finally {
       this.dbClient.commit();
     }

--- a/src/main/java/edu/berkeley/ground/resources/StructuresResource.java
+++ b/src/main/java/edu/berkeley/ground/resources/StructuresResource.java
@@ -62,10 +62,10 @@ public class StructuresResource {
   @GET
   @Timed
   @Path("/{name}")
-  public Structure getStructure(@PathParam("name") String name) throws GroundException {
+  public Structure getStructure(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving structure " + name + ".");
-      return this.structureFactory.retrieveFromDatabase(name);
+      LOGGER.info("Retrieving structure " + sourceKey + ".");
+      return this.structureFactory.retrieveFromDatabase(sourceKey);
     } finally {
       this.dbClient.commit();
     }
@@ -85,11 +85,11 @@ public class StructuresResource {
 
   @GET
   @Timed
-  @Path("/{name}/latest")
-  public List<Long> getLatestVersions(@PathParam("name") String name) throws GroundException {
+  @Path("/{sourceKey}/latest")
+  public List<Long> getLatestVersions(@PathParam("sourceKey") String sourceKey) throws GroundException {
     try {
-      LOGGER.info("Retrieving the latest version of node " + name + ".");
-      return this.structureFactory.getLeaves(name);
+      LOGGER.info("Retrieving the latest version of node " + sourceKey + ".");
+      return this.structureFactory.getLeaves(sourceKey);
     } finally {
       this.dbClient.commit();
     }

--- a/src/test/java/edu/berkeley/ground/dao/DaoTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/DaoTest.java
@@ -35,8 +35,8 @@ public class DaoTest {
   protected static NodesResource nodesResource;
   protected static StructuresResource structuresResource;
 
-  public static Node createNode(String name) throws GroundException {
-    return nodesResource.createNode(name, null, new HashMap<>());
+  public static Node createNode(String sourceKey) throws GroundException {
+    return nodesResource.createNode(null, sourceKey, new HashMap<>());
   }
 
   public static NodeVersion createNodeVersion(long nodeId) throws GroundException {
@@ -49,9 +49,9 @@ public class DaoTest {
         parents);
   }
 
-  public static Edge createEdge(String name, String fromNode, String toNode)
+  public static Edge createEdge(String sourceKey, String fromNode, String toNode)
       throws GroundException {
-    return edgesResource.createEdge(name, fromNode, toNode, null, new HashMap<>());
+    return edgesResource.createEdge(null, fromNode, toNode, sourceKey, new HashMap<>());
   }
 
   public static EdgeVersion createEdgeVersion(long edgeId, long fromStart, long toStart)
@@ -69,8 +69,8 @@ public class DaoTest {
         fromStart, -1, toStart, -1, parents);
   }
 
-  public static Graph createGraph(String name) throws GroundException {
-    return graphsResource.createGraph(name, null, new HashMap<>());
+  public static Graph createGraph(String sourceKey) throws GroundException {
+    return graphsResource.createGraph(null, sourceKey, new HashMap<>());
   }
 
   public static GraphVersion createGraphVersion(long graphId, List<Long> edgeVersionIds)
@@ -87,8 +87,8 @@ public class DaoTest {
         edgeVersionIds, parents);
   }
 
-  public static LineageEdge createLineageEdge(String name) throws GroundException {
-    return lineageEdgesResource.createLineageEdge(name, null, new HashMap<>());
+  public static LineageEdge createLineageEdge(String sourceKey) throws GroundException {
+    return lineageEdgesResource.createLineageEdge(null, sourceKey, new HashMap<>());
   }
 
   public static LineageEdgeVersion createLineageEdgeVersion(long lineageEdgeId,
@@ -107,8 +107,8 @@ public class DaoTest {
         new HashMap<>(), -1, null, fromId, toId, parents);
   }
 
-  public static LineageGraph createLineageGraph(String name) throws GroundException {
-    return lineageGraphsResource.createLineageGraph(name, null, new HashMap<>());
+  public static LineageGraph createLineageGraph(String sourceKey) throws GroundException {
+    return lineageGraphsResource.createLineageGraph(null, sourceKey, new HashMap<>());
   }
 
   public static LineageGraphVersion createLineageGraphVersion(long lineageGraphId,
@@ -128,8 +128,8 @@ public class DaoTest {
   }
 
 
-  public static Structure createStructure(String name) throws GroundException {
-    return structuresResource.createStructure(name, null, new HashMap<>());
+  public static Structure createStructure(String sourceKey) throws GroundException {
+    return structuresResource.createStructure(null, sourceKey, new HashMap<>());
   }
 
   public static StructureVersion createStructureVersion(long structureId) throws GroundException {

--- a/src/test/java/edu/berkeley/ground/dao/Neo4jTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/Neo4jTest.java
@@ -14,6 +14,7 @@
 
 package edu.berkeley.ground.dao;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -75,6 +76,11 @@ public class Neo4jTest extends DaoTest {
         factories.getNodeVersionFactory(), neo4jClient);
     structuresResource = new StructuresResource(factories.getStructureFactory(),
         factories.getStructureVersionFactory(), neo4jClient);
+  }
+
+  @AfterClass
+  public static void teardownClass() {
+    neo4jClient.close();
   }
 
   @Before

--- a/src/test/java/edu/berkeley/ground/dao/PostgresTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/PostgresTest.java
@@ -14,6 +14,8 @@
 
 package edu.berkeley.ground.dao;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -77,6 +79,11 @@ public class PostgresTest extends DaoTest {
         factories.getNodeVersionFactory(), postgresClient);
     structuresResource = new StructuresResource(factories.getStructureFactory(),
         factories.getStructureVersionFactory(), postgresClient);
+  }
+
+  @AfterClass
+  public static void teardownClass() throws GroundDbException {
+    // postgresClient.close();
   }
 
   @Before

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactoryTest.java
@@ -28,6 +28,7 @@ import edu.berkeley.ground.model.versions.VersionSuccessor;
 
 import static org.junit.Assert.*;
 
+// TODO: Once Cassandra schema is fixed, add duplicate edge tests
 public class CassandraEdgeFactoryTest extends CassandraTest {
 
   public CassandraEdgeFactoryTest() throws GroundException {
@@ -48,7 +49,7 @@ public class CassandraEdgeFactoryTest extends CassandraTest {
     CassandraTest.edgesResource.createEdge(testName, firstTestNode, secondTestNode, sourceKey,
         new HashMap<>());
 
-    Edge edge = CassandraTest.edgesResource.getEdge(testName);
+    Edge edge = CassandraTest.edgesResource.getEdge(sourceKey);
 
     assertEquals(testName, edge.getName());
     assertEquals(firstTestNodeId, edge.getFromNodeId());
@@ -56,14 +57,34 @@ public class CassandraEdgeFactoryTest extends CassandraTest {
     assertEquals(sourceKey, edge.getSourceKey());
   }
 
-  @Test(expected = GroundException.class)
-  public void testRetrieveBadEdge() throws GroundException {
-    String testName = "test";
+  // @Test(expected = GroundException.class)
+  public void testCreateDuplicateEdge() throws GroundException {
+    String edgeName = "edgeName";
+    String edgeKey = "edgeKey";
+    String fromNode = "fromNode";
+    String toNode = "toNode";
 
     try {
-      CassandraTest.edgesResource.getEdge(testName);
+      CassandraTest.createNode(fromNode);
+      CassandraTest.createNode(toNode);
+
+      CassandraTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
     } catch (GroundException e) {
-      assertEquals("No Edge found with name " + testName + ".", e.getMessage());
+      fail(e.getMessage());
+    }
+
+    CassandraTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
+  }
+
+
+  @Test(expected = GroundException.class)
+  public void testRetrieveBadEdge() throws GroundException {
+    String sourceKey = "test";
+
+    try {
+      CassandraTest.edgesResource.getEdge(sourceKey);
+    } catch (GroundException e) {
+      assertEquals("No Edge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraEdgeFactoryTest.java
@@ -28,7 +28,6 @@ import edu.berkeley.ground.model.versions.VersionSuccessor;
 
 import static org.junit.Assert.*;
 
-// TODO: Once Cassandra schema is fixed, add duplicate edge tests
 public class CassandraEdgeFactoryTest extends CassandraTest {
 
   public CassandraEdgeFactoryTest() throws GroundException {
@@ -57,7 +56,7 @@ public class CassandraEdgeFactoryTest extends CassandraTest {
     assertEquals(sourceKey, edge.getSourceKey());
   }
 
-  // @Test(expected = GroundException.class)
+  @Test(expected = GroundException.class)
   public void testCreateDuplicateEdge() throws GroundException {
     String edgeName = "edgeName";
     String edgeKey = "edgeKey";

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactoryTest.java
@@ -60,6 +60,21 @@ public class CassandraGraphFactoryTest extends CassandraTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateGraph() throws GroundException {
+    String graphName = "graphName";
+    String graphKey = "graphKey";
+
+    try {
+      CassandraTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    CassandraTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+  }
+
+
   @Test
   public void testTruncate() throws GroundException {
     long edgeVersionId = CassandraTest.createTwoNodesAndEdge();

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraGraphFactoryTest.java
@@ -41,7 +41,7 @@ public class CassandraGraphFactoryTest extends CassandraTest {
     String sourceKey = "testKey";
 
     CassandraTest.graphsResource.createGraph(testName, sourceKey, new HashMap<>());
-    Graph graph = CassandraTest.graphsResource.getGraph(testName);
+    Graph graph = CassandraTest.graphsResource.getGraph(sourceKey);
 
     assertEquals(testName, graph.getName());
     assertEquals(sourceKey, graph.getSourceKey());
@@ -49,12 +49,12 @@ public class CassandraGraphFactoryTest extends CassandraTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      CassandraTest.graphsResource.getGraph(testName);
+      CassandraTest.graphsResource.getGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Graph found with name " + testName + ".", e.getMessage());
+      assertEquals("No Graph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactoryTest.java
@@ -49,8 +49,8 @@ public class CassandraNodeFactoryTest extends CassandraTest {
     String sourceKey = "testKey";
 
     CassandraTest.nodesResource.createNode(testName, sourceKey,tagsMap);
+    Node node = CassandraTest.nodesResource.getNode(sourceKey);
 
-    Node node = CassandraTest.nodesResource.getNode(testName);
     assertEquals(testName, node.getName());
     assertEquals(tagsMap, node.getTags());
     assertEquals(sourceKey, node.getSourceKey());
@@ -58,13 +58,13 @@ public class CassandraNodeFactoryTest extends CassandraTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String nodeName = "testNode1";
-    long nodeId = CassandraTest.createNode(nodeName).getId();
+    String sourceKey = "testNode1";
+    long nodeId = CassandraTest.createNode(sourceKey).getId();
 
     long nodeVersionId = CassandraTest.createNodeVersion(nodeId).getId();
     long secondNodeVersionId = CassandraTest.createNodeVersion(nodeId).getId();
 
-    List<Long> leaves = CassandraTest.nodesResource.getLatestVersions(nodeName);
+    List<Long> leaves = CassandraTest.nodesResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(nodeVersionId));
     assertTrue(leaves.contains(secondNodeVersionId));
@@ -72,12 +72,12 @@ public class CassandraNodeFactoryTest extends CassandraTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadNode() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      CassandraTest.nodesResource.getNode(testName);
+      CassandraTest.nodesResource.getNode(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Node found with name " + testName + ".", e.getMessage());
+      assertEquals("No Node found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraNodeFactoryTest.java
@@ -83,6 +83,20 @@ public class CassandraNodeFactoryTest extends CassandraTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateNode() throws GroundException {
+    String nodeName = "nodeName";
+    String nodeKey = "nodeKey";
+
+    try {
+      CassandraTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    CassandraTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncation() throws GroundException {
     String testNode = "testNode";

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactoryTest.java
@@ -76,6 +76,20 @@ public class CassandraStructureFactoryTest extends CassandraTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateStructure() throws GroundException {
+    String structureName = "structureName";
+    String structureKey = "structureKey";
+
+    try {
+      CassandraTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    CassandraTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     String structureName = "testStructure1";

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraStructureFactoryTest.java
@@ -43,7 +43,7 @@ public class CassandraStructureFactoryTest extends CassandraTest {
     String sourceKey = "testKey";
 
     CassandraTest.structuresResource.createStructure(testName, sourceKey, new HashMap<>());
-    Structure structure = CassandraTest.structuresResource.getStructure(testName);
+    Structure structure = CassandraTest.structuresResource.getStructure(sourceKey);
 
     assertEquals(testName, structure.getName());
     assertEquals(sourceKey, structure.getSourceKey());
@@ -51,13 +51,13 @@ public class CassandraStructureFactoryTest extends CassandraTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String structureName = "testStructure1";
-    long structureId = CassandraTest.createStructure(structureName).getId();
+    String sourceKey = "testStructure";
+    long structureId = CassandraTest.createStructure(sourceKey).getId();
 
     long structureVersionId = CassandraTest.createStructureVersion(structureId).getId();
     long secondStructureVersionId = CassandraTest.createStructureVersion(structureId).getId();
 
-    List<Long> leaves = CassandraTest.structuresResource.getLatestVersions(structureName);
+    List<Long> leaves = CassandraTest.structuresResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(structureVersionId));
     assertTrue(leaves.contains(secondStructureVersionId));
@@ -65,12 +65,12 @@ public class CassandraStructureFactoryTest extends CassandraTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadStructure() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      CassandraTest.structuresResource.getStructure(testName);
+      CassandraTest.structuresResource.getStructure(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Structure found with name " + testName + ".", e.getMessage());
+      assertEquals("No Structure found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraTagFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/cassandra/CassandraTagFactoryTest.java
@@ -39,8 +39,8 @@ public class CassandraTagFactoryTest extends CassandraTest {
     Map<String, Tag> tagsMap = new HashMap<>();
     tagsMap.put("testtag", new Tag(1, "testtag", "tag", GroundType.STRING));
 
-    long nodeId1 = CassandraTest.nodesResource.createNode("test1", null, tagsMap).getId();
-    long nodeId2 = CassandraTest.nodesResource.createNode("test2", null, tagsMap).getId();
+    long nodeId1 = CassandraTest.nodesResource.createNode(null, "test1", tagsMap).getId();
+    long nodeId2 = CassandraTest.nodesResource.createNode(null, "test2", tagsMap).getId();
 
     List<Long> ids = CassandraTest.tagFactory.getItemIdsByTag("testtag");
 

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactoryTest.java
@@ -69,7 +69,7 @@ public class Neo4jEdgeFactoryTest extends Neo4jTest {
     }
   }
 
-  // @Test(expected = GroundException.class)
+  @Test(expected = GroundException.class)
   public void testCreateDuplicateEdge() throws GroundException {
     String edgeName = "edgeName";
     String edgeKey = "edgeKey";

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jEdgeFactoryTest.java
@@ -48,7 +48,7 @@ public class Neo4jEdgeFactoryTest extends Neo4jTest {
     Neo4jTest.edgesResource.createEdge(testName, firstNodeName, secondNodeName, sourceKey,
         new HashMap<>());
 
-    Edge edge = Neo4jTest.edgesResource.getEdge(testName);
+    Edge edge = Neo4jTest.edgesResource.getEdge(sourceKey);
 
     assertEquals(testName, edge.getName());
     assertEquals(firstNodeId, edge.getFromNodeId());
@@ -58,16 +58,36 @@ public class Neo4jEdgeFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadEdge() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      super.edgesResource.getEdge(testName);
+      Neo4jTest.edgesResource.getEdge(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Edge found with name " + testName + ".", e.getMessage());
+      assertEquals("No Edge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }
   }
+
+  // @Test(expected = GroundException.class)
+  public void testCreateDuplicateEdge() throws GroundException {
+    String edgeName = "edgeName";
+    String edgeKey = "edgeKey";
+    String fromNode = "fromNode";
+    String toNode = "toNode";
+
+    try {
+      Neo4jTest.createNode(fromNode);
+      Neo4jTest.createNode(toNode);
+
+      Neo4jTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
+  }
+
 
   @Test
   public void testTruncation() throws GroundException {

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactoryTest.java
@@ -40,7 +40,7 @@ public class Neo4jGraphFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.graphsResource.createGraph(testName, sourceKey, new HashMap<>());
-    Graph graph = Neo4jTest.graphsResource.getGraph(testName);
+    Graph graph = Neo4jTest.graphsResource.getGraph(sourceKey);
 
     assertEquals(testName, graph.getName());
     assertEquals(sourceKey, graph.getSourceKey());
@@ -48,12 +48,12 @@ public class Neo4jGraphFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      Neo4jTest.graphsResource.getGraph(testName);
+      Neo4jTest.graphsResource.getGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Graph found with name " + testName + ".", e.getMessage());
+      assertEquals("No Graph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jGraphFactoryTest.java
@@ -59,6 +59,20 @@ public class Neo4jGraphFactoryTest extends Neo4jTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateGraph() throws GroundException {
+    String graphName = "graphName";
+    String graphKey = "graphKey";
+
+    try {
+      Neo4jTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     long edgeVersionId = Neo4jTest.createTwoNodesAndEdge();

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactoryTest.java
@@ -122,6 +122,21 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateNode() throws GroundException {
+    String nodeName = "nodeName";
+    String nodeKey = "nodeKey";
+
+    try {
+      Neo4jTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+  }
+
+
   @Test
   public void testTruncation() throws GroundException {
     String testNode = "testNode";

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jNodeFactoryTest.java
@@ -50,7 +50,7 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.nodesResource.createNode(testName, sourceKey, tagsMap);
-    Node node = Neo4jTest.nodesResource.getNode(testName);
+    Node node = Neo4jTest.nodesResource.getNode(sourceKey);
 
     assertEquals(testName, node.getName());
     assertEquals(tagsMap, node.getTags());
@@ -66,7 +66,7 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.nodesResource.createNode(testName, sourceKey, tagsMap);
-    Node node = Neo4jTest.nodesResource.getNode(testName);
+    Node node = Neo4jTest.nodesResource.getNode(sourceKey);
 
     assertEquals(testName, node.getName());
     assertEquals(tagsMap, node.getTags());
@@ -98,12 +98,12 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String nodeName = "testNode1";
-    long nodeId = Neo4jTest.createNode(nodeName).getId();
+    String sourceKey = "testNode1";
+    long nodeId = Neo4jTest.createNode(sourceKey).getId();
     long nodeVersionId = Neo4jTest.createNodeVersion(nodeId).getId();
     long secondNodeVersionId = Neo4jTest.createNodeVersion(nodeId).getId();
 
-    List<Long> leaves = Neo4jTest.nodesResource.getLatestVersions(nodeName);
+    List<Long> leaves = Neo4jTest.nodesResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(nodeVersionId));
     assertTrue(leaves.contains(secondNodeVersionId));
@@ -111,12 +111,12 @@ public class Neo4jNodeFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadNode() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      Neo4jTest.nodesResource.getNode(testName);
+      Neo4jTest.nodesResource.getNode(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Node found with name " + testName + ".", e.getMessage());
+      assertEquals("No Node found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactoryTest.java
@@ -42,7 +42,7 @@ public class Neo4jStructureFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.structuresResource.createStructure(testName, sourceKey, new HashMap<>());
-    Structure structure = Neo4jTest.structuresResource.getStructure(testName);
+    Structure structure = Neo4jTest.structuresResource.getStructure(sourceKey);
 
     assertEquals(testName, structure.getName());
     assertEquals(sourceKey, structure.getSourceKey());
@@ -50,12 +50,12 @@ public class Neo4jStructureFactoryTest extends Neo4jTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String structureName = "testStructure1";
-    long structureId = Neo4jTest.createStructure(structureName).getId();
+    String sourceKey = "testStructure";
+    long structureId = Neo4jTest.createStructure(sourceKey).getId();
     long structureVersionId = Neo4jTest.createStructureVersion(structureId).getId();
     long secondStructureVersionId = Neo4jTest.createStructureVersion(structureId).getId();
 
-    List<Long> leaves = Neo4jTest.structuresResource.getLatestVersions(structureName);
+    List<Long> leaves = Neo4jTest.structuresResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(structureVersionId));
     assertTrue(leaves.contains(secondStructureVersionId));
@@ -63,12 +63,12 @@ public class Neo4jStructureFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadStructure() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      Neo4jTest.structuresResource.getStructure(testName);
+      Neo4jTest.structuresResource.getStructure(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Structure found with name " + testName + ".", e.getMessage());
+      assertEquals("No Structure found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jStructureFactoryTest.java
@@ -74,6 +74,21 @@ public class Neo4jStructureFactoryTest extends Neo4jTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateStructure() throws GroundException {
+    String structureName = "structureName";
+    String structureKey = "structureKey";
+
+    try {
+      Neo4jTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+  }
+
+
   @Test
   public void testTruncate() throws GroundException {
     String structureName = "testStructure";

--- a/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jTagFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/neo4j/Neo4jTagFactoryTest.java
@@ -39,8 +39,8 @@ public class Neo4jTagFactoryTest extends Neo4jTest {
     Map<String, Tag> tagsMap = new HashMap<>();
     tagsMap.put("testtag", new Tag(1, "testtag", "tag", GroundType.STRING));
 
-    long nodeId1 = Neo4jTest.nodesResource.createNode("test1", null, tagsMap).getId();
-    long nodeId2 = Neo4jTest.nodesResource.createNode("test2", null, tagsMap).getId();
+    long nodeId1 = Neo4jTest.nodesResource.createNode(null, "test1", tagsMap).getId();
+    long nodeId2 = Neo4jTest.nodesResource.createNode(null, "test2", tagsMap).getId();
 
     List<Long> ids = Neo4jTest.tagFactory.getItemIdsByTag("testtag");
 

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresEdgeFactoryTest.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToDoubleBiFunction;
+
+import javax.ws.rs.POST;
 
 import edu.berkeley.ground.dao.PostgresTest;
 import edu.berkeley.ground.model.models.Edge;
@@ -50,7 +53,7 @@ public class PostgresEdgeFactoryTest extends PostgresTest {
     PostgresTest.edgesResource.createEdge(testName, fromNodeName, toNodeName, sourceKey,
         new HashMap<>());
 
-    Edge edge = PostgresTest.edgesResource.getEdge(testName);
+    Edge edge = PostgresTest.edgesResource.getEdge(sourceKey);
 
     assertEquals(testName, edge.getName());
     assertEquals(fromNodeId, edge.getFromNodeId());
@@ -60,15 +63,34 @@ public class PostgresEdgeFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadEdge() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.edgesResource.getEdge(testName);
+      PostgresTest.edgesResource.getEdge(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Edge found with name " + testName + ".", e.getMessage());
+      assertEquals("No Edge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }
+  }
+
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateEdge() throws GroundException {
+    String edgeName = "edgeName";
+    String edgeKey = "edgeKey";
+    String fromNode = "fromNode";
+    String toNode = "toNode";
+
+    try {
+      PostgresTest.createNode(fromNode);
+      PostgresTest.createNode(toNode);
+
+      PostgresTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.edgesResource.createEdge(edgeName, fromNode, toNode, edgeKey, new HashMap<>());
   }
 
   @Test

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactoryTest.java
@@ -60,6 +60,20 @@ public class PostgresGraphFactoryTest extends PostgresTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateGraph() throws GroundException {
+    String graphName = "graphName";
+    String graphKey = "graphKey";
+
+    try {
+      PostgresTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.graphsResource.createGraph(graphName, graphKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     long edgeVersionId = PostgresTest.createTwoNodesAndEdge();

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresGraphFactoryTest.java
@@ -41,7 +41,7 @@ public class PostgresGraphFactoryTest extends PostgresTest {
     String sourceKey = "testKey";
 
     PostgresTest.graphsResource.createGraph(testName, sourceKey, new HashMap<>());
-    Graph graph = PostgresTest.graphsResource.getGraph(testName);
+    Graph graph = PostgresTest.graphsResource.getGraph(sourceKey);
 
     assertEquals(testName, graph.getName());
     assertEquals(sourceKey, graph.getSourceKey());
@@ -49,12 +49,12 @@ public class PostgresGraphFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.graphsResource.getGraph(testName);
+      PostgresTest.graphsResource.getGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Graph found with name " + testName + ".", e.getMessage());
+      assertEquals("No Graph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactoryTest.java
@@ -83,6 +83,20 @@ public class PostgresNodeFactoryTest extends PostgresTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateNode() throws GroundException {
+    String nodeName = "nodeName";
+    String nodeKey = "nodeKey";
+
+    try {
+      PostgresTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.nodesResource.createNode(nodeName, nodeKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncation() throws GroundException {
     String testNode = "testNode";

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresNodeFactoryTest.java
@@ -50,7 +50,7 @@ public class PostgresNodeFactoryTest extends PostgresTest {
 
     PostgresTest.nodesResource.createNode(testName, sourceKey,tagsMap);
 
-    Node node = PostgresTest.nodesResource.getNode(testName);
+    Node node = PostgresTest.nodesResource.getNode(sourceKey);
     assertEquals(testName, node.getName());
     assertEquals(tagsMap, node.getTags());
     assertEquals(sourceKey, node.getSourceKey());
@@ -58,13 +58,13 @@ public class PostgresNodeFactoryTest extends PostgresTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String nodeName = "testNode1";
-    long nodeId = PostgresTest.createNode(nodeName).getId();
+    String sourceKey = "testNode1";
+    long nodeId = PostgresTest.createNode(sourceKey).getId();
 
     long nodeVersionId = PostgresTest.createNodeVersion(nodeId).getId();
     long secondNodeVersionId = PostgresTest.createNodeVersion(nodeId).getId();
 
-    List<Long> leaves = PostgresTest.nodesResource.getLatestVersions(nodeName);
+    List<Long> leaves = PostgresTest.nodesResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(nodeVersionId));
     assertTrue(leaves.contains(secondNodeVersionId));
@@ -72,12 +72,12 @@ public class PostgresNodeFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadNode() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.nodesResource.getNode(testName);
+      PostgresTest.nodesResource.getNode(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Node found with name " + testName + ".", e.getMessage());
+      assertEquals("No Node found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactoryTest.java
@@ -76,6 +76,21 @@ public class PostgresStructureFactoryTest extends PostgresTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateStructure() throws GroundException {
+    String structureName = "structureName";
+    String structureKey = "structureKey";
+
+    try {
+      PostgresTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.structuresResource.createStructure(structureName, structureKey, new HashMap<>());
+  }
+
+
   @Test
   public void testTruncate() throws GroundException {
     String structureName = "testStructure1";

--- a/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/models/postgres/PostgresStructureFactoryTest.java
@@ -43,7 +43,7 @@ public class PostgresStructureFactoryTest extends PostgresTest {
     String sourceKey = "testKey";
 
     PostgresTest.structuresResource.createStructure(testName, sourceKey, new HashMap<>());
-    Structure structure = PostgresTest.structuresResource.getStructure(testName);
+    Structure structure = PostgresTest.structuresResource.getStructure(sourceKey);
 
     assertEquals(testName, structure.getName());
     assertEquals(sourceKey, structure.getSourceKey());
@@ -51,13 +51,13 @@ public class PostgresStructureFactoryTest extends PostgresTest {
 
   @Test
   public void testLeafRetrieval() throws GroundException {
-    String structureName = "testStructure1";
-    long structureId = PostgresTest.createStructure(structureName).getId();
+    String sourceKey = "testStructure";
+    long structureId = PostgresTest.createStructure(sourceKey).getId();
 
     long structureVersionId = PostgresTest.createStructureVersion(structureId).getId();
     long secondStructureVersionId = PostgresTest.createStructureVersion(structureId).getId();
 
-    List<Long> leaves = PostgresTest.structuresResource.getLatestVersions(structureName);
+    List<Long> leaves = PostgresTest.structuresResource.getLatestVersions(sourceKey);
 
     assertTrue(leaves.contains(structureVersionId));
     assertTrue(leaves.contains(secondStructureVersionId));
@@ -65,12 +65,12 @@ public class PostgresStructureFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadStructure() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.structuresResource.getStructure(testName);
+      PostgresTest.structuresResource.getStructure(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No Structure found with name " + testName + ".", e.getMessage());
+      assertEquals("No Structure found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactoryTest.java
@@ -40,7 +40,7 @@ public class CassandraLineageEdgeFactoryTest extends CassandraTest {
     String sourceKey = "testKey";
 
     CassandraTest.lineageEdgesResource.createLineageEdge(testName, sourceKey, new HashMap<>());
-    LineageEdge lineageEdge = CassandraTest.lineageEdgesResource.getLineageEdge(testName);
+    LineageEdge lineageEdge = CassandraTest.lineageEdgesResource.getLineageEdge(sourceKey);
 
     assertEquals(testName, lineageEdge.getName());
     assertEquals(sourceKey, lineageEdge.getSourceKey());
@@ -48,12 +48,12 @@ public class CassandraLineageEdgeFactoryTest extends CassandraTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageEdge() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      CassandraTest.lineageEdgesResource.getLineageEdge(testName);
+      CassandraTest.lineageEdgesResource.getLineageEdge(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageEdge found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageEdge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageEdgeFactoryTest.java
@@ -59,6 +59,20 @@ public class CassandraLineageEdgeFactoryTest extends CassandraTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageEdge() throws GroundException {
+    String lineageEdgeName = "lineageEdgeName";
+    String lineageEdgeKey = "lineageEdgeKey";
+
+    try {
+      CassandraTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    CassandraTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     String firstTestNode = "firstTestNode";

--- a/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactoryTest.java
@@ -26,7 +26,7 @@ import edu.berkeley.ground.exceptions.GroundException;
 import edu.berkeley.ground.model.versions.VersionHistoryDag;
 import edu.berkeley.ground.model.versions.VersionSuccessor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class CassandraLineageGraphFactoryTest extends CassandraTest {
 
@@ -57,6 +57,22 @@ public class CassandraLineageGraphFactoryTest extends CassandraTest {
 
       throw e;
     }
+  }
+
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageGraph() throws GroundException {
+    String lineageGraphName = "lineageGraphName";
+    String lineageGraphKey = "lineageGraphKey";
+
+    try {
+      CassandraTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+          lineageGraphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    CassandraTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+        lineageGraphKey, new HashMap<>());
   }
 
   @Test

--- a/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/cassandra/CassandraLineageGraphFactoryTest.java
@@ -40,7 +40,7 @@ public class CassandraLineageGraphFactoryTest extends CassandraTest {
     String sourceKey = "testKey";
 
     CassandraTest.lineageGraphsResource.createLineageGraph(testName, sourceKey, new HashMap<>());
-    LineageGraph graph = CassandraTest.lineageGraphsResource.getLineageGraph(testName);
+    LineageGraph graph = CassandraTest.lineageGraphsResource.getLineageGraph(sourceKey);
 
     assertEquals(testName, graph.getName());
     assertEquals(sourceKey, graph.getSourceKey());
@@ -48,12 +48,12 @@ public class CassandraLineageGraphFactoryTest extends CassandraTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      CassandraTest.lineageGraphsResource.getLineageGraph(testName);
+      CassandraTest.lineageGraphsResource.getLineageGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageGraph found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageGraph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactoryTest.java
@@ -45,6 +45,20 @@ public class Neo4jLineageEdgeFactoryTest extends Neo4jTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageEdge() throws GroundException {
+    String lineageEdgeName = "lineageEdgeName";
+    String lineageEdgeKey = "lineageEdgeKey";
+
+    try {
+      Neo4jTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     String firstTestNode = "firstTestNode";

--- a/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageEdgeFactoryTest.java
@@ -26,7 +26,7 @@ public class Neo4jLineageEdgeFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.lineageEdgesResource.createLineageEdge(testName, sourceKey, new HashMap<>());
-    LineageEdge lineageEdge = Neo4jTest.lineageEdgesResource.getLineageEdge(testName);
+    LineageEdge lineageEdge = Neo4jTest.lineageEdgesResource.getLineageEdge(sourceKey);
 
     assertEquals(testName, lineageEdge.getName());
     assertEquals(sourceKey, lineageEdge.getSourceKey());
@@ -34,12 +34,12 @@ public class Neo4jLineageEdgeFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageEdge() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      Neo4jTest.lineageEdgesResource.getLineageEdge(testName);
+      Neo4jTest.lineageEdgesResource.getLineageEdge(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageEdge found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageEdge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactoryTest.java
@@ -12,7 +12,7 @@ import edu.berkeley.ground.exceptions.GroundException;
 import edu.berkeley.ground.model.versions.VersionHistoryDag;
 import edu.berkeley.ground.model.versions.VersionSuccessor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class Neo4jLineageGraphFactoryTest extends Neo4jTest {
 
@@ -43,6 +43,22 @@ public class Neo4jLineageGraphFactoryTest extends Neo4jTest {
 
       throw e;
     }
+  }
+
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageGraph() throws GroundException {
+    String lineageGraphName = "lineageGraphName";
+    String lineageGraphKey = "lineageGraphKey";
+
+    try {
+      Neo4jTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+          lineageGraphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    Neo4jTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+        lineageGraphKey, new HashMap<>());
   }
 
   @Test

--- a/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/neo4j/Neo4jLineageGraphFactoryTest.java
@@ -26,7 +26,7 @@ public class Neo4jLineageGraphFactoryTest extends Neo4jTest {
     String sourceKey = "testKey";
 
     Neo4jTest.lineageGraphsResource.createLineageGraph(testName, sourceKey, new HashMap<>());
-    LineageGraph lineageGraph = Neo4jTest.lineageGraphsResource.getLineageGraph(testName);
+    LineageGraph lineageGraph = Neo4jTest.lineageGraphsResource.getLineageGraph(sourceKey);
 
     assertEquals(testName, lineageGraph.getName());
     assertEquals(sourceKey, lineageGraph.getSourceKey());
@@ -34,12 +34,12 @@ public class Neo4jLineageGraphFactoryTest extends Neo4jTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      Neo4jTest.lineageGraphsResource.getLineageGraph(testName);
+      Neo4jTest.lineageGraphsResource.getLineageGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageGraph found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageGraph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactoryTest.java
@@ -26,7 +26,7 @@ public class PostgresLineageEdgeFactoryTest extends PostgresTest {
     String sourceKey = "testKey";
 
     PostgresTest.lineageEdgesResource.createLineageEdge(testName, sourceKey, new HashMap<>());
-    LineageEdge lineageEdge = PostgresTest.lineageEdgesResource.getLineageEdge(testName);
+    LineageEdge lineageEdge = PostgresTest.lineageEdgesResource.getLineageEdge(sourceKey);
 
     assertEquals(testName, lineageEdge.getName());
     assertEquals(sourceKey, lineageEdge.getSourceKey());
@@ -34,12 +34,12 @@ public class PostgresLineageEdgeFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageEdge() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.lineageEdgesResource.getLineageEdge(testName);
+      PostgresTest.lineageEdgesResource.getLineageEdge(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageEdge found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageEdge found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageEdgeFactoryTest.java
@@ -45,6 +45,20 @@ public class PostgresLineageEdgeFactoryTest extends PostgresTest {
     }
   }
 
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageEdge() throws GroundException {
+    String lineageEdgeName = "lineageEdgeName";
+    String lineageEdgeKey = "lineageEdgeKey";
+
+    try {
+      PostgresTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.lineageEdgesResource.createLineageEdge(lineageEdgeName, lineageEdgeKey, new HashMap<>());
+  }
+
   @Test
   public void testTruncate() throws GroundException {
     String firstTestNode = "firstTestNode";

--- a/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactoryTest.java
@@ -26,7 +26,7 @@ public class PostgresLineageGraphFactoryTest extends PostgresTest {
     String sourceKey = "testKey";
 
     PostgresTest.lineageGraphsResource.createLineageGraph(testName, sourceKey, new HashMap<>());
-    LineageGraph graph = PostgresTest.lineageGraphsResource.getLineageGraph(testName);
+    LineageGraph graph = PostgresTest.lineageGraphsResource.getLineageGraph(sourceKey);
 
     assertEquals(testName, graph.getName());
     assertEquals(sourceKey, graph.getSourceKey());
@@ -34,12 +34,12 @@ public class PostgresLineageGraphFactoryTest extends PostgresTest {
 
   @Test(expected = GroundException.class)
   public void testRetrieveBadLineageGraph() throws GroundException {
-    String testName = "test";
+    String sourceKey = "test";
 
     try {
-      PostgresTest.lineageGraphsResource.getLineageGraph(testName);
+      PostgresTest.lineageGraphsResource.getLineageGraph(sourceKey);
     } catch (GroundException e) {
-      assertEquals("No LineageGraph found with name " + testName + ".", e.getMessage());
+      assertEquals("No LineageGraph found with source_key " + sourceKey + ".", e.getMessage());
 
       throw e;
     }

--- a/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactoryTest.java
+++ b/src/test/java/edu/berkeley/ground/dao/usage/postgres/PostgresLineageGraphFactoryTest.java
@@ -12,7 +12,7 @@ import edu.berkeley.ground.exceptions.GroundException;
 import edu.berkeley.ground.model.versions.VersionHistoryDag;
 import edu.berkeley.ground.model.versions.VersionSuccessor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class PostgresLineageGraphFactoryTest extends PostgresTest {
 
@@ -43,6 +43,22 @@ public class PostgresLineageGraphFactoryTest extends PostgresTest {
 
       throw e;
     }
+  }
+
+  @Test(expected = GroundException.class)
+  public void testCreateDuplicateLineageGraph() throws GroundException {
+    String lineageGraphName = "lineageGraphName";
+    String lineageGraphKey = "lineageGraphKey";
+
+    try {
+      PostgresTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+          lineageGraphKey, new HashMap<>());
+    } catch (GroundException e) {
+      fail(e.getMessage());
+    }
+
+    PostgresTest.lineageGraphsResource.createLineageGraph(lineageGraphName,
+        lineageGraphKey, new HashMap<>());
   }
 
   @Test


### PR DESCRIPTION
* Change all APIs to use source keys instead of names
* Enforce uniqueness in Neo4j and Cassandra by retrieving `Item`s before creating them
* Add tests to make sure you cannot create duplicate keys