### PR TITLE
controllers: Fix bug in caching to use different keys

### DIFF
--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/EdgeController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/EdgeController.java
@@ -46,7 +46,7 @@ public class EdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "edges",
+            "edges." + sourceKey,
             () -> Json.toJson(this.postgresEdgeDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -83,7 +83,7 @@ public class EdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "edge_versions",
+            "edge_versions." + id,
             () -> Json.toJson(this.postgresEdgeVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -123,7 +123,7 @@ public class EdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "edge_leaves",
+            "edge_leaves." + sourceKey,
             () -> Json.toJson(this.postgresEdgeDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -140,7 +140,7 @@ public class EdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "edge_history",
+            "edge_history." + sourceKey,
             () -> Json.toJson(this.postgresEdgeDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {

--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/GraphController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/GraphController.java
@@ -58,7 +58,7 @@ public class GraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "graphs",
+            "graphs." + sourceKey,
             () -> Json.toJson(this.postgresGraphDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -74,7 +74,7 @@ public class GraphController extends Controller {
     return CompletableFuture.supplyAsync(
       () -> {
         try {
-          return this.cache.getOrElse("graph_versions",
+          return this.cache.getOrElse("graph_versions." + id,
             () -> Json.toJson(this.postgresGraphVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -132,7 +132,7 @@ public class GraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "graph_leaves",
+            "graph_leaves." + sourceKey,
             () -> Json.toJson(this.postgresGraphDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -149,7 +149,7 @@ public class GraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "graph_history",
+            "graph_history." + sourceKey,
             () -> Json.toJson(this.postgresGraphDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {

--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/LineageEdgeController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/LineageEdgeController.java
@@ -46,7 +46,7 @@ public class LineageEdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_edges",
+            "lineage_edges." + sourceKey,
             () -> Json.toJson(this.postgresLineageEdgeDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -63,7 +63,7 @@ public class LineageEdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_edge_versions",
+            "lineage_edge_versions." + id,
             () -> Json.toJson(this.postgresLineageEdgeVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -120,7 +120,7 @@ public class LineageEdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_edge_leaves",
+            "lineage_edge_leaves." + sourceKey,
             () -> Json.toJson(this.postgresLineageEdgeDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -137,7 +137,7 @@ public class LineageEdgeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_edge_history",
+            "lineage_edge_history." + sourceKey,
             () -> Json.toJson(this.postgresLineageEdgeDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {

--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/LineageGraphController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/LineageGraphController.java
@@ -47,7 +47,7 @@ public class LineageGraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_graphs",
+            "lineage_graphs." + sourceKey,
             () -> Json.toJson(this.postgresLineageGraphDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -64,7 +64,7 @@ public class LineageGraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_graph_versions",
+            "lineage_graph_versions." + id,
             () -> Json.toJson(this.postgresLineageGraphVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -121,7 +121,7 @@ public class LineageGraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_graph__leaves",
+            "lineage_graph_leaves." + sourceKey,
             () -> Json.toJson(this.postgresLineageGraphDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -138,7 +138,7 @@ public class LineageGraphController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "lineage_graph__history",
+            "lineage_graph_history." + sourceKey,
             () -> Json.toJson(this.postgresLineageGraphDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {

--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/NodeController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/NodeController.java
@@ -46,7 +46,7 @@ public class NodeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "nodes",
+            "nodes." + sourceKey,
             () -> Json.toJson(this.postgresNodeDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -81,7 +81,7 @@ public class NodeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "node_versions",
+            "node_versions." + id,
             () -> Json.toJson(this.postgresNodeVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -121,7 +121,7 @@ public class NodeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "node_leaves",
+            "node_leaves." + sourceKey,
             () -> Json.toJson(this.postgresNodeDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -138,7 +138,7 @@ public class NodeController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "node_history",
+            "node_history." + sourceKey,
             () -> Json.toJson(this.postgresNodeDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {

--- a/modules/postgres/app/edu/berkeley/ground/postgres/controllers/StructureController.java
+++ b/modules/postgres/app/edu/berkeley/ground/postgres/controllers/StructureController.java
@@ -57,7 +57,7 @@ public class StructureController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "structures",
+            "structures." + sourceKey,
             () -> Json.toJson(this.postgresStructureDao.retrieveFromDatabase(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -73,7 +73,7 @@ public class StructureController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "structure_versions",
+            "structure_versions." + id,
             () -> Json.toJson(this.postgresStructureVersionDao.retrieveFromDatabase(id)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -132,7 +132,7 @@ public class StructureController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "structure_leaves",
+            "structure_leaves." + sourceKey,
             () -> Json.toJson(this.postgresStructureDao.getLeaves(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {
@@ -149,7 +149,7 @@ public class StructureController extends Controller {
       () -> {
         try {
           return this.cache.getOrElse(
-            "structure_history",
+            "structure_history." + sourceKey,
             () -> Json.toJson(this.postgresStructureDao.getHistory(sourceKey)),
             Integer.parseInt(System.getProperty("ground.cache.expire.secs")));
         } catch (Exception e) {


### PR DESCRIPTION
Previous caching logic in the controllers used the same key to cache any `Edge`, `EdgeVersion`, etc. retrieved. As a result, if you retrieve two different `Edge`s or (or `Node`s or...) in rapid succession, you would get the same one returned twice. Fixes #101. 