### PR TITLE
Add Postgres setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ For the vision behind Ground, please see our [CIDR '17](http://cidrdb.org/cidr20
 You can download the latest version of Ground from our [releases page](https://github.com/ground-context/ground/releases).
 The most recent version of Ground is [**v0.1.2**](https://github.com/ground-context/ground/releases/tag/v0.1.2).
 
-Once you have downloaded the latest version of Ground, you can start the Ground server by running `./bin/ground-postgres`.
+Once you have downloaded the latest version of Ground, a Ground database and corresponding tables are necessary for Ground to function.
+To create the tables, please run `python postgres_setup.py <user> <dbname>` in the `db/` directory of the release.
+To drop the tables, run `python postgres_setup.py <user> <dbname> drop`.
+Alternatively, one can also use `db/postgres.sql` to set up the tables. 
+
+You can start the Ground server by running `./bin/ground-postgres`.
 This starts a local Ground server running on port 9000.
 
 For more information, see [Hit the Ground Running](http://ground-context.org/wiki/), our getting started guide.


### PR DESCRIPTION
I spent some time creating the Postgres tables until I found that there exists a setup script. I don't think this is documented anywhere. 

It would be nice if the DB and tables were setup upon initialization though, as referenced in #96.
