### PR TITLE
Adding Python Implementation of Ground

### DIFF
--- a/ground.py
+++ b/ground.py
@@ -1,0 +1,1309 @@
+# /usr/bin/env python3
+import requests
+import json
+import numpy as np
+import os
+import git
+import subprocess
+from shutil import copyfile
+
+
+class Node:
+    def __init__(self, sourceKey=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.tags = tags
+        self.name = name
+        self.nodeId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'tags': self.tags,
+            'name': self.name,
+            'nodeId': self.nodeId,
+            'class': 'Node'
+        }
+        return json.dumps(d)
+
+
+class NodeVersion:
+    def __init__(self, node=Node(), reference=None, referenceParameters=None, tags=None,
+                 structureVersionId=None, parentIds=None):
+        self.sourceKey = node.sourceKey
+        self.nodeId = node.nodeId
+        self.reference = reference
+        self.referenceParameters = referenceParameters
+        self.tags = tags
+        self.structureVersionId = structureVersionId
+        self.parentIds = parentIds
+        self.nodeVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'nodeId': self.nodeId,
+            'reference': self.reference,
+            'referenceParameters': self.referenceParameters,
+            'tags': self.tags,
+            'structureVersionId': self.structureVersionId,
+            'parentIds': self.parentIds,
+            'nodeVersionId': self.nodeVersionId,
+            'class': 'NodeVersion'
+        }
+        return json.dumps(d)
+
+
+class Edge:
+    def __init__(self, sourceKey=None, fromNodeId=None, toNodeId=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.fromNodeId = fromNodeId
+        self.toNodeId = toNodeId
+        self.name = name
+        self.tags = tags
+        self.edgeId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'fromNodeId': self.fromNodeId,
+            'toNodeId': self.toNodeId,
+            'name': self.name,
+            'tags': self.tags,
+            'edgeId': self.edgeId,
+            'class': 'Edge'
+        }
+        return json.dumps(d)
+
+
+class EdgeVersion:
+    def __init__(self, edge=Edge(), toNodeVersionStartId=None, fromNodeVersionStartId=None, toNodeVersionEndId=None,
+                 fromNodeVersionEndId=None, reference=None, referenceParameters=None,
+                 tags=None, structureVersionId=None, parentIds=None):
+        self.sourceKey = edge.sourceKey
+        self.fromNodeId = edge.fromNodeId
+        self.toNodeId = edge.toNodeId
+        self.edgeId = edge.edgeId
+        self.toNodeVersionStartId = toNodeVersionStartId
+        self.fromNodeVersionStartId = fromNodeVersionStartId
+        self.toNodeVersionEndId = toNodeVersionEndId
+        self.fromNodeVersionEndId = fromNodeVersionEndId
+        self.reference = reference
+        self.referenceParameters = referenceParameters
+        self.tags = tags
+        self.structureVersionId = structureVersionId
+        self.parentIds = parentIds
+        self.edgeVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'fromNodeId': self.fromNodeId,
+            'toNodeId': self.toNodeId,
+            'edgeId': self.edgeId,
+            'toNodeVersionStartId': self.toNodeVersionStartId,
+            'fromNodeVersionStartId': self.fromNodeVersionStartId,
+            'toNodeVersionEndId': self.toNodeVersionEndId,
+            'fromNodeVersionEndId': self.fromNodeVersionEndId,
+            'reference': self.reference,
+            'referenceParameters': self.referenceParameters,
+            'tags': self.tags,
+            'structureVersionId': self.structureVersionId,
+            'parentIds': self.parentIds,
+            'edgeVersionId': self.edgeVersionId,
+            'class': 'EdgeVersion'
+        }
+        return json.dumps(d)
+
+
+class Graph:
+    def __init__(self, sourceKey=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.name = name
+        self.tags = tags
+        self.graphId = None
+
+        self.nodes = {}
+        self.nodeVersions = {}
+        self.edges = {}
+        self.edgeVersions = {}
+        self.graphs = {}
+        self.graphVersions = {}
+        self.structures = {}
+        self.structureVersions = {}
+        self.lineageEdges = {}
+        self.lineageEdgeVersions = {}
+        self.lineageGraphs = {}
+        self.lineageGraphVersions = {}
+        self.ids = set([])
+
+        self.__loclist__ = []
+        self.__scriptNames__ = []
+
+    def gen_id(self):
+        newid = len(self.ids)
+        self.ids |= {newid}
+        return newid
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'tags': self.tags,
+            'name': self.name,
+            'graphId': self.graphId,
+            'class': 'Graph'
+        }
+        return json.dumps(d)
+
+
+class GraphVersion:
+    def __init__(self, graph=Graph(), edgeVersionIds=None, reference=None, referenceParameters=None,
+                 tags=None, structureVersionId=None, parentIds=None):
+        self.sourceKey = graph.sourceKey
+        self.graphId = graph.graphId
+        self.edgeVersionIds = edgeVersionIds
+        self.structureVersionId = structureVersionId
+        self.reference = reference
+        self.referenceParameters = referenceParameters
+        self.tags = tags
+        self.parentIds = parentIds
+        self.graphVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'graphId': self.graphId,
+            'edgeVersionIds': self.edgeVersionIds,
+            'structureVersionId': self.structureVersionId,
+            'reference': self.reference,
+            'referenceParameters': self.referenceParameters,
+            'tags': self.tags,
+            'parentIds': self.parentIds,
+            'graphVersionId': self.graphVersionId,
+            'class': 'GraphVersion'
+        }
+        return json.dumps(d)
+
+
+class Structure:
+    def __init__(self, sourceKey=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.name = name
+        self.tags = tags
+        self.structureId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'tags': self.tags,
+            'name': self.name,
+            'structureId': self.structureId,
+            'class': 'Structure'
+        }
+        return json.dumps(d)
+
+
+class StructureVersion:
+    def __init__(self, structure=Structure(), attributes=None, parentIds=None):
+        self.sourceKey = structure.sourceKey
+        self.structureId = structure.structureId
+        self.attributes = attributes
+        self.parentIds = parentIds
+        self.structureVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'structureId': self.structureId,
+            'attributes': self.attributes,
+            'parentIds': self.parentIds,
+            'structureVersionId': self.structureVersionId,
+            'class': 'StructureVersion'
+        }
+        return json.dumps(d)
+
+
+class LineageEdge:
+    def __init__(self, sourceKey=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.name = name
+        self.tags = tags
+        self.lineageEdgeId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'name': self.name,
+            'tags': self.tags,
+            'lineageEdgeId': self.lineageEdgeId,
+            'class': 'LineageEdge'
+        }
+        return json.dumps(d)
+
+
+class LineageEdgeVersion:
+    def __init__(self, lineageEdge=LineageEdge(), toRichVersionId=None, fromRichVersionId=None, reference=None,
+                 referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        self.sourceKey = lineageEdge.sourceKey
+        self.lineageEdgeId = lineageEdge.lineageEdgeId
+        self.toRichVersionId = toRichVersionId
+        self.fromRichVersionId = fromRichVersionId
+        self.reference = reference
+        self.referenceParameters = referenceParameters
+        self.tags = tags
+        self.structureVersionId = structureVersionId
+        self.parentIds = parentIds
+        self.lineageEdgeVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'lineageEdgeId': self.lineageEdgeId,
+            'fromRichVersionId': self.fromRichVersionId,
+            'toRichVersionId': self.toRichVersionId,
+            'reference': self.reference,
+            'referenceParameters': self.referenceParameters,
+            'tags': self.tags,
+            'structureVersionId': self.structureVersionId,
+            'parentIds': self.parentIds,
+            'lineageEdgeVersionId': self.lineageEdgeVersionId,
+            'class': 'LineageEdgeVersion'
+        }
+        return json.dumps(d)
+
+
+class LineageGraph:
+    def __init__(self, sourceKey=None, name=None, tags=None):
+        self.sourceKey = sourceKey
+        self.name = name
+        self.tags = tags
+        self.lineageGraphId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'name': self.name,
+            'tags': self.tags,
+            'lineageGraphId': self.lineageGraphId,
+            'class': 'LineageGraph'
+        }
+        return json.dumps(d)
+
+
+class LineageGraphVersion:
+    def __init__(self, lineageGraph=LineageGraph(), lineageEdgeVersionIds=None, reference=None,
+                 referenceParameters=None,
+                 tags=None, structureVersionId=None, parentIds=None):
+        self.sourceKey = lineageGraph.sourceKey
+        self.lineageGraphId = lineageGraph.lineageGraphId
+        self.lineageEdgeVersionIds = lineageEdgeVersionIds
+        self.reference = reference
+        self.referenceParameters = referenceParameters
+        self.tags = tags
+        self.structureVersionId = structureVersionId
+        self.parentIds = parentIds
+        self.lineageGraphVersionId = None
+
+    def to_json(self):
+        d = {
+            'sourceKey': self.sourceKey,
+            'lineageGraphId': self.lineageGraphId,
+            'lineageEdgeVersionIds': self.lineageEdgeVersionIds,
+            'reference': self.reference,
+            'referenceParameters': self.referenceParameters,
+            'tags': self.tags,
+            'structureVersionId': self.structureVersionId,
+            'parentIds': self.parentIds,
+            'lineageGraphVersionId': self.lineageGraphVersionId,
+            'class': 'LineageGraphVersion'
+        }
+        return json.dumps(d)
+
+
+"""
+Abstract class: do not instantiate
+"""
+
+
+class GroundAPI:
+    headers = {"Content-type": "application/json"}
+
+    ### EDGES ###
+    def createEdge(self, sourceKey, fromNodeId, toNodeId, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "fromNodeId": fromNodeId,
+            "toNodeId": toNodeId,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createEdgeVersion(self, edgeId, toNodeVersionStartId, fromNodeVersionStartId, toNodeVersionEndId=None,
+                          fromNodeVersionEndId=None, reference=None, referenceParameters=None, tags=None,
+                          structureVersionId=None, parentIds=None):
+        d = {
+            "edgeId": edgeId,
+            "fromNodeVersionStartId": fromNodeVersionStartId,
+            "toNodeVersionStartId": toNodeVersionStartId
+        }
+        if toNodeVersionEndId is not None:
+            d["toNodeVersionEndId"] = toNodeVersionEndId
+        if fromNodeVersionEndId is not None:
+            d["fromNodeVersionEndId"] = fromNodeVersionEndId
+        if reference is not None:
+            d["reference"] = reference
+        if referenceParameters is not None:
+            d["referenceParameters"] = referenceParameters
+        if tags is not None:
+            d["tags"] = tags
+        if structureVersionId is not None:
+            d["structureVersionId"] = structureVersionId
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getEdge(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getEdge")
+
+    def getEdgeLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getEdgeLatestVersions")
+
+    def getEdgeHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getEdgeHistory")
+
+    def getEdgeVersion(self, edgeId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getEdgeVersion")
+
+    ### NODES ###
+    def createNode(self, sourceKey, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createNodeVersion(self, nodeId, reference=None, referenceParameters=None, tags=None,
+                          structureVersionId=None, parentIds=None):
+        d = {
+            "nodeId": nodeId
+        }
+        if reference is not None:
+            d["reference"] = reference
+        if referenceParameters is not None:
+            d["referenceParameters"] = referenceParameters
+        if tags is not None:
+            d["tags"] = tags
+        if structureVersionId is not None:
+            d["structureVersionId"] = structureVersionId
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getNode(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getNode")
+
+    def getNodeLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getNodeLatestVersions")
+
+    def getNodeHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getNodeHistory")
+
+    def getNodeVersion(self, nodeId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getNodeVersion")
+
+    def getNodeVersionAdjacentLineage(self, nodeId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getNodeVersionAdjacentLineage")
+
+    ### GRAPHS ###
+    def createGraph(self, sourceKey, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createGraphVersion(self, graphId, edgeVersionIds, reference=None, referenceParameters=None,
+                           tags=None, structureVersionId=None, parentIds=None):
+        d = {
+            "graphId": graphId,
+            "edgeVersionIds": edgeVersionIds
+        }
+        if reference is not None:
+            d["reference"] = reference
+        if referenceParameters is not None:
+            d["referenceParameters"] = referenceParameters
+        if tags is not None:
+            d["tags"] = tags
+        if structureVersionId is not None:
+            d["structureVersionId"] = structureVersionId
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getGraph(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getGraph")
+
+    def getGraphLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getGraphLatestVersions")
+
+    def getGraphHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getGraphHistory")
+
+    def getGraphVersion(self, graphId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getGraphVersion")
+
+    ### STRUCTURES ###
+    def createStructure(self, sourceKey, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createStructureVersion(self, structureId, attributes, parentIds=None):
+        d = {
+            "structureId": structureId,
+            "attributes": attributes
+        }
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getStructure(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getStructure")
+
+    def getStructureLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getStructureLatestVersions")
+
+    def getStructureHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getStructureHistory")
+
+    def getStructureVersion(self, structureId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getStructureVersion")
+
+    ### LINEAGE EDGES ###
+    def createLineageEdge(self, sourceKey, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createLineageEdgeVersion(self, lineageEdgeId, toRichVersionId, fromRichVersionId, reference=None,
+                                 referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        d = {
+            "lineageEdgeId": lineageEdgeId,
+            "toRichVersionId": toRichVersionId,
+            "fromRichVersionId": fromRichVersionId
+        }
+        if reference is not None:
+            d["reference"] = reference
+        if referenceParameters is not None:
+            d["referenceParameters"] = referenceParameters
+        if tags is not None:
+            d["tags"] = tags
+        if structureVersionId is not None:
+            d["structureVersionId"] = structureVersionId
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getLineageEdge(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getLineageEdge")
+
+    def getLineageEdgeLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageEdgeLatestVersions")
+
+    def getLineageEdgeHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageEdgeHistory")
+
+    def getLineageEdgeVersion(self, lineageEdgeId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageEdgeVersion")
+
+    ### LINEAGE GRAPHS ###
+    def createLineageGraph(self, sourceKey, name="null", tags=None):
+        d = {
+            "sourceKey": sourceKey,
+            "name": name
+        }
+        if tags is not None:
+            d["tags"] = tags
+        return d
+
+    def createLineageGraphVersion(self, lineageGraphId, lineageEdgeVersionIds, reference=None,
+                                  referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        d = {
+            "lineageGraphId": lineageGraphId,
+            "lineageEdgeVersionIds": lineageEdgeVersionIds
+        }
+        if reference is not None:
+            d["reference"] = reference
+        if referenceParameters is not None:
+            d["referenceParameters"] = referenceParameters
+        if tags is not None:
+            d["tags"] = tags
+        if structureVersionId is not None:
+            d["structureVersionId"] = structureVersionId
+        if parentIds is not None:
+            d["parentIds"] = parentIds
+        return d
+
+    def getLineageGraph(self, sourceKey):
+        raise NotImplementedError("Invalid call to GroundClient.getLineageGraph")
+
+    def getLineageGraphLatestVersions(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageGraphLatestVersions")
+
+    def getLineageGraphHistory(self, sourceKey):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageGraphHistory")
+
+    def getLineageGraphVersion(self, lineageGraphId):
+        raise NotImplementedError(
+            "Invalid call to GroundClient.getLineageGraphVersion")
+
+    def commit(self, directory=None):
+        return
+
+    def load(self, directory):
+        """
+        This method is implemented by GitImplementation
+        It is used to load the Ground Graph to memory (from filesystem)
+        """
+        return
+
+
+class GitImplementation(GroundAPI):
+    def __init__(self):
+        self.graph = Graph()
+
+    def __run_proc__(self, bashCommand):
+        process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        return str(output, 'UTF-8')
+
+        ### EDGES ###
+
+    def createEdge(self, sourceKey, fromNodeId, toNodeId, name="null", tags=None):
+        if sourceKey not in self.graph.edges:
+            edgeid = self.graph.gen_id()
+            edge = Edge(sourceKey, fromNodeId, toNodeId, name, tags)
+            edge.edgeId = edgeid
+
+            self.graph.edges[sourceKey] = edge
+            self.graph.edges[edgeid] = edge
+        else:
+            edgeid = self.graph.edges[sourceKey].edgeId
+
+        return edgeid
+
+    def createEdgeVersion(self, edgeId, toNodeVersionStartId, fromNodeVersionStartId, toNodeVersionEndId=None,
+                          fromNodeVersionEndId=None, reference=None, referenceParameters=None, tags=None,
+                          structureVersionId=None, parentIds=None):
+        edge = Edge()
+        if (edgeId in self.graph.edges):
+            edge = self.graph.edges[edgeId]
+        edgeVersion = EdgeVersion(edge, toNodeVersionStartId, fromNodeVersionStartId, toNodeVersionEndId,
+                                  fromNodeVersionEndId, reference, referenceParameters, tags,
+                                  structureVersionId, parentIds)
+
+        edgeversionid = self.graph.gen_id()
+        edgeVersion.edgeVersionId = edgeversionid
+
+        if edgeVersion.sourceKey in self.graph.edgeVersions:
+            self.graph.edgeVersions[edgeVersion.sourceKey].append(edgeVersion)
+        else:
+            self.graph.edgeVersions[edgeVersion.sourceKey] = [edgeVersion, ]
+        self.graph.edgeVersions[edgeversionid] = edgeVersion
+        return edgeversionid
+
+    def getEdge(self, sourceKey):
+        return self.graph.edges[sourceKey]
+
+    def getEdgeLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.edgeVersions
+        edgeVersions = set(self.graph.edgeVersions[sourceKey])
+        is_parent = set([])
+        for ev in edgeVersions:
+            if ev.parentIds:
+                assert type(ev.parentIds) == list
+                for parentId in ev.parentIds:
+                    is_parent |= {self.graph.edgeVersions[parentId], }
+        return list(edgeVersions - is_parent)
+
+    def getEdgeHistory(self, sourceKey):
+        assert sourceKey in self.graph.edgeVersions
+        parentChild = {}
+        for ev in self.graph.edgeVersions[sourceKey]:
+            if ev.parentIds:
+                assert type(ev.parentIds) == list
+                for parentId in ev.parentIds:
+                    if not parentChild:
+                        edgeId = ev.edgeId
+                        parentChild[str(edgeId)] = parentId
+                    parentChild[str(parentId)] = ev.edgeVersionId
+        return parentChild
+
+    def getEdgeVersion(self, edgeVersionId):
+        return self.graph.edgeVersions[edgeVersionId]
+
+    ### NODES ###
+    def createNode(self, sourceKey, name="null", tags=None):
+        if sourceKey not in self.graph.nodes:
+            nodeid = self.graph.gen_id()
+            node = Node(sourceKey, name, tags)
+            node.nodeId = nodeid
+
+            self.graph.nodes[sourceKey] = node
+            self.graph.nodes[nodeid] = node
+        else:
+            nodeid = self.graph.nodes[sourceKey].nodeId
+
+        return nodeid
+
+    def createNodeVersion(self, nodeId, reference=None, referenceParameters=None, tags=None,
+                          structureVersionId=None, parentIds=None):
+        node = Node()
+        if (nodeId in self.graph.nodes):
+            node = self.graph.nodes[nodeId]
+        nodeVersion = NodeVersion(node, reference, referenceParameters, tags, structureVersionId, parentIds)
+        # else:
+        #     # Match node versions with the same tags.
+        #     # ALERT: THIS MAY NOT GENERALIZE TO K-LIFTING
+        #     nlvs = self.getNodeLatestVersions(self.graph.nodes[nodeId].sourceKey)
+        #     if nlvs:
+        #         nodeVersion.parentIds = nlvs
+        #     else:
+        #         nodeVersion.parentIds = None
+        nodeversionid = self.graph.gen_id()
+        nodeVersion.nodeVersionId = nodeversionid
+
+        if nodeVersion.sourceKey in self.graph.nodeVersions:
+            self.graph.nodeVersions[nodeVersion.sourceKey].append(nodeVersion)
+        else:
+            self.graph.nodeVersions[nodeVersion.sourceKey] = [nodeVersion, ]
+        self.graph.nodeVersions[nodeversionid] = nodeVersion
+        return nodeversionid
+
+    def getNode(self, sourceKey):
+        return self.graph.nodes[sourceKey]
+
+    def getNodeLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.nodeVersions
+        nodeVersions = set(self.graph.nodeVersions[sourceKey])
+        is_parent = set([])
+        for nv in nodeVersions:
+            if nv.parentIds:
+                assert type(nv.parentIds) == list
+                for parentId in nv.parentIds:
+                    is_parent |= {self.graph.nodeVersions[parentId], }
+        return list(nodeVersions - is_parent)
+
+    def getNodeHistory(self, sourceKey):
+        assert sourceKey in self.graph.nodeVersions
+        parentChild = {}
+        for nv in self.graph.nodeVersions[sourceKey]:
+            if nv.parentIds:
+                assert type(nv.parentIds) == list
+                for parentId in nv.parentIds:
+                    if not parentChild:
+                        nodeId = nv.nodeId
+                        parentChild[str(nodeId)] = parentId
+                    parentChild[str(parentId)] = nv.nodeVersionId
+        return parentChild
+
+    def getNodeVersion(self, nodeVersionId):
+        return self.graph.nodeVersions[nodeVersionId]
+
+    def getNodeVersionAdjacentLineage(self, nodeVersionId):
+        assert nodeVersionId in self.graph.nodeVersions
+        lineageEdgeVersions = (self.graph.lineageEdgeVersions).values()
+        adjacent = []
+        for lev in lineageEdgeVersions:
+            if isinstance(lev, LineageEdgeVersion):
+                if ((nodeVersionId == lev.toRichVersionId) or (nodeVersionId == lev.fromRichVersionId)):
+                    adjacent.append(lev)
+        return list(set(adjacent))
+
+    ### GRAPHS ###
+    def createGraph(self, sourceKey, name="null", tags=None):
+        if sourceKey not in self.graph.graphs:
+            graphid = self.graph.gen_id()
+            graph = Graph(sourceKey, name, tags)
+            graph.graphId = graphid
+
+            self.graph.graphs[sourceKey] = graph
+            self.graph.graphs[graphid] = graph
+        else:
+            graphid = self.graph.graphs[sourceKey].graphId
+
+        return graphid
+
+    def createGraphVersion(self, graphId, edgeVersionIds, reference=None,
+                           referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        graph = Graph()
+        if (graphId in self.graph.graphs):
+            graph = self.graph.graphs[graphId]
+        graphVersion = GraphVersion(graph, edgeVersionIds, reference,
+                                    referenceParameters, tags, structureVersionId, parentIds)
+
+        graphversionid = self.graph.gen_id()
+        graphVersion.graphVersionId = graphversionid
+
+        if graphVersion.sourceKey in self.graph.graphVersions:
+            self.graph.graphVersions[graphVersion.sourceKey].append(graphVersion)
+        else:
+            self.graph.graphVersions[graphVersion.sourceKey] = [graphVersion, ]
+        self.graph.graphVersions[graphversionid] = graphVersion
+        return graphversionid
+
+    def getGraph(self, sourceKey):
+        return self.graph.graphs[sourceKey]
+
+    def getGraphLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.graphVersions
+        graphVersions = set(self.graph.graphVersions[sourceKey])
+        is_parent = set([])
+        for gv in graphVersions:
+            if gv.parentIds:
+                assert type(gv.parentIds) == list
+                for parentId in gv.parentIds:
+                    is_parent |= {self.graph.graphVersions[parentId], }
+        return list(graphVersions - is_parent)
+
+    def getGraphHistory(self, sourceKey):
+        assert sourceKey in self.graph.graphVersions
+        parentChild = {}
+        for gv in self.graph.graphVersions[sourceKey]:
+            if gv.parentIds:
+                assert type(gv.parentIds) == list
+                for parentId in gv.parentIds:
+                    if not parentChild:
+                        graphId = gv.graphId
+                        parentChild[str(graphId)] = parentId
+                    parentChild[str(parentId)] = gv.graphVersionId
+        return parentChild
+
+    def getGraphVersion(self, graphVersionId):
+        return self.graph.graphVersions[graphVersionId]
+
+    ### STRUCTURES ###
+    def createStructure(self, sourceKey, name="null", tags=None):
+        if sourceKey not in self.graph.structures:
+            structureid = self.graph.gen_id()
+            structure = Structure(sourceKey, name, tags)
+            structure.structureId = structureid
+
+            self.graph.structures[sourceKey] = structure
+            self.graph.structures[structureid] = structure
+        else:
+            structureid = self.graph.structures[sourceKey].structureId
+
+        return structureid
+
+    def createStructureVersion(self, structureId, attributes, parentIds=None):
+        structure = Structure()
+        if (structureId in self.graph.structures):
+            structure = self.graph.structures[structureId]
+        structureVersion = StructureVersion(structure, attributes, parentIds)
+
+        structureversionid = self.graph.gen_id()
+        structureVersion.structureVersionId = structureversionid
+
+        if structureVersion.sourceKey in self.graph.structureVersions:
+            self.graph.structureVersions[structureVersion.sourceKey].append(structureVersion)
+        else:
+            self.graph.structureVersions[structureVersion.sourceKey] = [structureVersion, ]
+        self.graph.structureVersions[structureversionid] = structureVersion
+        return structureversionid
+
+    def getStructure(self, sourceKey):
+        return self.graph.structures[sourceKey]
+
+    def getStructureLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.structureVersions
+        structureVersions = set(self.graph.structureVersions[sourceKey])
+        is_parent = set([])
+        for sv in structureVersions:
+            if sv.parentIds:
+                assert type(sv.parentIds) == list
+                for parentId in sv.parentIds:
+                    is_parent |= {self.graph.structureVersions[parentId], }
+        return list(structureVersions - is_parent)
+
+    def getStructureHistory(self, sourceKey):
+        assert sourceKey in self.graph.structureVersions
+        parentChild = {}
+        for sv in self.graph.structureVersions[sourceKey]:
+            if sv.parentIds:
+                assert type(sv.parentIds) == list
+                for parentId in sv.parentIds:
+                    if not parentChild:
+                        structureId = sv.structureId
+                        parentChild[str(structureId)] = parentId
+                    parentChild[str(parentId)] = sv.structureVersionId
+        return parentChild
+
+    def getStructureVersion(self, structureVersionId):
+        return self.graph.structureVersions[structureVersionId]
+
+    ### LINEAGE EDGES ###
+    def createLineageEdge(self, sourceKey, name="null", tags=None):
+        if sourceKey not in self.graph.lineageEdges:
+            lineageedgeid = self.graph.gen_id()
+            lineageEdge = LineageEdge(sourceKey, name, tags)
+            lineageEdge.lineageEdgeId = lineageedgeid
+
+            self.graph.lineageEdges[sourceKey] = lineageEdge
+            self.graph.lineageEdges[lineageedgeid] = lineageEdge
+        else:
+            lineageedgeid = self.graph.lineageEdges[sourceKey].lineageEdgeId
+
+        return lineageedgeid
+
+    def createLineageEdgeVersion(self, lineageEdgeId, toRichVersionId, fromRichVersionId, reference=None,
+                                 referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        lineageEdge = LineageEdge()
+        if (lineageEdgeId in self.graph.lineageEdges):
+            lineageEdge = self.graph.lineageEdges[lineageEdgeId]
+        lineageEdgeVersion = LineageEdgeVersion(lineageEdge, toRichVersionId, fromRichVersionId, reference,
+                                                referenceParameters, tags, structureVersionId, parentIds)
+
+        lineageedgeversionid = self.graph.gen_id()
+        lineageEdgeVersion.lineageEdgeVersionId = lineageedgeversionid
+
+        if lineageEdgeVersion.sourceKey in self.graph.lineageEdgeVersions:
+            self.graph.lineageEdgeVersions[lineageEdgeVersion.sourceKey].append(lineageEdgeVersion)
+        else:
+            self.graph.lineageEdgeVersions[lineageEdgeVersion.sourceKey] = [lineageEdgeVersion, ]
+        self.graph.lineageEdgeVersions[lineageedgeversionid] = lineageEdgeVersion
+        return lineageedgeversionid
+
+    def getLineageEdge(self, sourceKey):
+        return self.graph.lineageEdges[sourceKey]
+
+    def getLineageEdgeLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.lineageEdgeVersions
+        lineageEdgeVersions = set(self.graph.lineageEdgeVersions[sourceKey])
+        is_parent = set([])
+        for lev in lineageEdgeVersions:
+            if lev.parentIds:
+                assert type(lev.parentIds) == list
+                for parentId in lev.parentIds:
+                    is_parent |= {self.graph.lineageEdgeVersions[parentId], }
+        return list(lineageEdgeVersions - is_parent)
+
+    def getLineageEdgeHistory(self, sourceKey):
+        assert sourceKey in self.graph.lineageEdgeVersions
+        parentChild = {}
+        for lev in self.graph.lineageEdgeVersions[sourceKey]:
+            if lev.parentIds:
+                assert type(lev.parentIds) == list
+                for parentId in lev.parentIds:
+                    if not parentChild:
+                        lineageEdgeId = lev.lineageEdgeId
+                        parentChild[str(lineageEdgeId)] = parentId
+                    parentChild[str(parentId)] = lev.lineageEdgeVersionId
+        return parentChild
+
+    def getLineageEdgeVersion(self, lineageEdgeVersionId):
+        return self.graph.lineageEdgeVersions[lineageEdgeVersionId]
+
+    ### LINEAGE GRAPHS ###
+    def createLineageGraph(self, sourceKey, name="null", tags=None):
+        if sourceKey not in self.graph.lineageGraphs:
+            lineagegraphid = self.graph.gen_id()
+            lineageGraph = LineageGraph(sourceKey, name, tags)
+            lineageGraph.lineageGraphId = lineagegraphid
+
+            self.graph.lineageGraphs[sourceKey] = lineageGraph
+            self.graph.lineageGraphs[lineagegraphid] = lineageGraph
+        else:
+            lineagegraphid = self.graph.lineageGraphs[sourceKey].lineageGraphId
+
+        return lineagegraphid
+
+    def createLineageGraphVersion(self, lineageGraphId, lineageEdgeVersionIds, reference=None,
+                                  referenceParameters=None, tags=None, structureVersionId=None, parentIds=None):
+        lineageGraph = LineageGraph()
+        if (lineageGraphId in self.graph.lineageGraphs):
+            lineageGraph = self.graph.lineageGraphs[lineageGraphId]
+        lineageGraphVersion = LineageGraphVersion(lineageGraph, lineageEdgeVersionIds, reference,
+                                                  referenceParameters, tags, structureVersionId, parentIds)
+
+        lineagegraphversionid = self.graph.gen_id()
+        lineageGraphVersion.lineageGraphVersionId = lineagegraphversionid
+
+        if lineageGraphVersion.sourceKey in self.graph.lineageGraphVersions:
+            self.graph.lineageGraphVersions[lineageGraphVersion.sourceKey].append(lineageGraphVersion)
+        else:
+            self.graph.lineageGraphVersions[lineageGraphVersion.sourceKey] = [lineageGraphVersion, ]
+        self.graph.lineageGraphVersions[lineagegraphversionid] = lineageGraphVersion
+        return lineagegraphversionid
+
+    def getLineageGraph(self, sourceKey):
+        return self.graph.lineageGraphs[sourceKey]
+
+    def getLineageGraphLatestVersions(self, sourceKey):
+        assert sourceKey in self.graph.lineageGraphVersions
+        lineageGraphVersions = set(self.graph.lineageGraphVersions[sourceKey])
+        is_parent = set([])
+        for gev in lineageGraphVersions:
+            if gev.parentIds:
+                assert type(gev.parentIds) == list
+                for parentId in gev.parentIds:
+                    is_parent |= {self.graph.lineageGraphVersions[parentId], }
+        return list(lineageGraphVersions - is_parent)
+
+    def getLineageGraphHistory(self, sourceKey):
+        assert sourceKey in self.graph.lineageGraphVersions
+        parentChild = {}
+        for gev in self.graph.lineageGraphVersions[sourceKey]:
+            if gev.parentIds:
+                assert type(gev.parentIds) == list
+                for parentId in gev.parentIds:
+                    if not parentChild:
+                        lineageGraphId = gev.lineageGraphId
+                        parentChild[str(lineageGraphId)] = parentId
+                    parentChild[str(parentId)] = gev.lineageGraphVersionId
+        return parentChild
+
+    def getLineageGraphVersion(self, lineageGraphVersionId):
+        return self.graph.lineageGraphVersions[lineageGraphVersionId]
+
+    def commit(self):
+        stage = []
+        for kee in self.graph.ids:
+            if kee in self.graph.nodes:
+                serial = self.graph.nodes[kee].to_json()
+            elif kee in self.graph.nodeVersions:
+                serial = self.graph.nodeVersions[kee].to_json()
+            elif kee in self.graph.edges:
+                serial = self.graph.edges[kee].to_json()
+            elif kee in self.graph.edgeVersions:
+                serial = self.graph.edgeVersions[kee].to_json()
+            elif kee in self.graph.graphs:
+                serial = self.graph.graphs[kee].to_json()
+            elif kee in self.graph.graphVersions:
+                serial = self.graph.graphVersions[kee].to_json()
+            elif kee in self.graph.structures:
+                serial = self.graph.structures[kee].to_json()
+            elif kee in self.graph.structureVersions:
+                serial = self.graph.structureVersions[kee].to_json()
+            elif kee in self.graph.lineageEdges:
+                serial = self.graph.lineageEdges[kee].to_json()
+            elif kee in self.graph.lineageEdgeVersions:
+                serial = self.graph.lineageEdgeVersions[kee].to_json()
+            elif kee in self.graph.lineageGraphs:
+                serial = self.graph.lineageGraphs[kee].to_json()
+            else:
+                serial = self.graph.lineageGraphVersions[kee].to_json()
+            assert serial is not None
+            with open(str(kee) + '.json', 'w') as f:
+                f.write(serial)
+            stage.append(str(kee) + '.json')
+        repo = git.Repo.init(os.getcwd())
+        repo.index.add(stage)
+        repo.index.commit("ground commit")
+        tree = repo.tree()
+        with open('.jarvis', 'w') as f:
+            for obj in tree:
+                commithash = self.__run_proc__("git log " + obj.path).replace('\n', ' ').split()[1]
+                if obj.path != '.jarvis':
+                    f.write(obj.path + " " + commithash + "\n")
+        repo.index.add(['.jarvis'])
+        repo.index.commit('.jarvis commit')
+
+    def to_class(self, obj):
+        if obj['class'] == 'Node':
+            n = Node()
+            n.sourceKey = obj['sourceKey']
+            n.nodeId = obj['nodeId']
+            if 'name' in obj:
+                n.name = obj['name']
+            if 'tags' in obj:
+                n.tags = obj['tags']
+
+            self.graph.nodes[n.sourceKey] = n
+            self.graph.nodes[n.nodeId] = n
+            self.graph.ids |= {n.nodeId, }
+
+        elif obj['class'] == 'NodeVersion':
+            nv = NodeVersion()
+            nv.sourceKey = obj['sourceKey']
+            nv.nodeId = obj['nodeId']
+            nv.nodeVersionId = obj['nodeVersionId']
+            if 'tags' in obj:
+                nv.tags = obj['tags']
+            if 'structureVersionId' in obj:
+                nv.structureVersionId = obj['structureVersionId']
+            if 'reference' in obj:
+                nv.reference = obj['reference']
+            if 'referenceParameters' in obj:
+                nv.referenceParameters = obj['referenceParameters']
+            if 'parentIds' in obj:
+                nv.parentIds = obj['parentIds']
+
+            if nv.sourceKey in self.graph.nodeVersions:
+                self.graph.nodeVersions[nv.sourceKey].append(nv)
+            else:
+                self.graph.nodeVersions[nv.sourceKey] = [nv, ]
+            self.graph.nodeVersions[nv.nodeVersionId] = nv
+            self.graph.ids |= {nv.nodeVersionId, }
+
+        elif obj['class'] == 'Edge':
+            e = Edge()
+            e.sourceKey = obj['sourceKey']
+            e.fromNodeId = obj['fromNodeId']
+            e.toNodeId = obj['toNodeId']
+            e.edgeId = obj['edgeId']
+            if 'name' in obj:
+                e.name = obj['name']
+            if 'tags' in obj:
+                e.tags = obj['tags']
+
+            self.graph.edges[e.sourceKey] = e
+            self.graph.edges[e.edgeId] = e
+            self.graph.ids |= {e.edgeId, }
+
+        elif obj['class'] == 'EdgeVersion':
+            ev = EdgeVersion()
+            ev.sourceKey = obj['sourceKey']
+            ev.edgeId = obj['edgeId']
+            ev.toNodeVersionStartId = obj['toNodeVersionStartId']
+            ev.fromNodeVersionStartId = obj['fromNodeVersionStartId']
+            ev.edgeVersionId = obj['edgeVersionId']
+            if 'tags' in obj:
+                ev.tags = obj['tags']
+            if 'structureVersionId' in obj:
+                ev.structureVersionId = obj['structureVersionId']
+            if 'reference' in obj:
+                ev.reference = obj['reference']
+            if 'referenceParameters' in obj:
+                ev.referenceParameters = obj['referenceParameters']
+            if 'toNodeVersionEndId' in obj:
+                ev.toNodeVersionEndId = obj['toNodeVersionEndId']
+            if 'fromNodeVersionEndId' in obj:
+                ev.fromNodeVersionEndId = obj['fromNodeVersionEndId']
+            if 'parentIds' in obj:
+                ev.parentIds = obj['parentIds']
+
+            if ev.sourceKey in self.graph.edgeVersions:
+                self.graph.edgeVersions[ev.sourceKey].append(ev)
+            else:
+                self.graph.edgeVersions[ev.sourceKey] = [ev, ]
+            self.graph.edgeVersions[ev.edgeVersionId] = ev
+            self.graph.ids |= {ev.edgeVersionId, }
+
+        elif obj['class'] == 'Graph':
+            g = Graph()
+            g.sourceKey = obj['sourceKey']
+            g.graphId = obj['graphId']
+            if 'name' in obj:
+                g.name = obj['name']
+            if 'tags' in obj:
+                g.tags = obj['tags']
+
+            self.graph.graphs[g.sourceKey] = g
+            self.graph.graphs[g.graphId] = g
+            self.graph.ids |= {g.graphId, }
+
+        elif obj['class'] == 'GraphVersion':
+            gv = GraphVersion()
+            gv.sourceKey = obj['sourceKey']
+            gv.graphId = obj['graphId']
+            gv.edgeVersionIds = obj['edgeVersionIds']
+            gv.graphVersionId = obj['graphVersionId']
+            if 'tags' in obj:
+                gv.tags = obj['tags']
+            if 'structureVersionId' in obj:
+                gv.structureVersionId = obj['structureVersionId']
+            if 'reference' in obj:
+                gv.reference = obj['reference']
+            if 'referenceParameters' in obj:
+                gv.referenceParameters = obj['referenceParameters']
+            if 'parentIds' in obj:
+                gv.parentIds = obj['parentIds']
+
+            if gv.sourceKey in self.graph.graphVersions:
+                self.graph.graphVersions[gv.sourceKey].append(gv)
+            else:
+                self.graph.graphVersions[gv.sourceKey] = [gv, ]
+            self.graph.graphVersions[gv.graphVersionId] = gv
+            self.graph.ids |= {gv.graphVersionId, }
+
+        elif obj['class'] == 'Structure':
+            s = Structure()
+            s.sourceKey = obj['sourceKey']
+            s.structureId = obj['structureId']
+            if 'name' in obj:
+                s.name = obj['name']
+            if 'tags' in obj:
+                s.tags = obj['tags']
+
+            self.graph.structures[s.sourceKey] = s
+            self.graph.structures[s.structureId] = s
+            self.graph.ids |= {s.structureId, }
+
+        elif obj['class'] == 'StructureVersion':
+            sv = StructureVersion()
+            sv.sourceKey = obj['sourceKey']
+            sv.structureId = obj['structureId']
+            sv.attributes = obj['attributes']
+            sv.structureVersionId = obj['structureVersionId']
+            if 'parentIds' in obj:
+                sv.parentIds = obj['parentIds']
+
+            if sv.sourceKey in self.graph.structureVersions:
+                self.graph.structureVersions[sv.sourceKey].append(sv)
+            else:
+                self.graph.structureVersions[sv.sourceKey] = [sv, ]
+            self.graph.structureVersions[sv.structureVersionId] = sv
+            self.graph.ids |= {sv.structureVersionId, }
+
+        elif obj['class'] == 'LineageEdge':
+            le = LineageEdge()
+            le.sourceKey = obj['sourceKey']
+            le.lineageEdgeId = obj['lineageEdgeId']
+            if 'name' in obj:
+                le.name = obj['name']
+            if 'tags' in obj:
+                le.tags = obj['tags']
+
+            self.graph.lineageEdges[le.sourceKey] = le
+            self.graph.lineageEdges[le.lineageEdgeId] = le
+            self.graph.ids |= {le.lineageEdgeId, }
+
+        elif obj['class'] == 'LineageEdgeVersion':
+            lev = LineageEdgeVersion()
+            lev.sourceKey = obj['sourceKey']
+            lev.lineageEdgeId = obj['lineageEdgeId']
+            lev.toRichVersionId = obj['toRichVersionId']
+            lev.fromRichVersionId = obj['fromRichVersionId']
+            lev.lineageEdgeVersionId = obj['lineageEdgeVersionId']
+            if 'tags' in obj:
+                lev.tags = obj['tags']
+            if 'structureVersionId' in obj:
+                lev.structureVersionId = obj['structureVersionId']
+            if 'reference' in obj:
+                lev.reference = obj['reference']
+            if 'referenceParameters' in obj:
+                lev.referenceParameters = obj['referenceParameters']
+            if 'parentIds' in obj:
+                lev.parentIds = obj['parentIds']
+
+            if lev.sourceKey in self.graph.lineageEdgeVersions:
+                self.graph.lineageEdgeVersions[lev.sourceKey].append(lev)
+            else:
+                self.graph.lineageEdgeVersions[lev.sourceKey] = [lev, ]
+            self.graph.lineageEdgeVersions[lev.lineageEdgeVersionId] = lev
+            self.graph.ids |= {lev.lineageEdgeVersionId, }
+
+        elif obj['class'] == 'LineageGraph':
+            ge = LineageGraph()
+            ge.sourceKey = obj['sourceKey']
+            ge.lineageGraphId = obj['lineageGraphId']
+            if 'name' in obj:
+                ge.name = obj['name']
+            if 'tags' in obj:
+                ge.tags = obj['tags']
+
+            self.graph.lineageGraphs[ge.sourceKey] = ge
+            self.graph.lineageGraphs[ge.lineageGraphId] = ge
+            self.graph.ids |= {ge.lineageGraphId, }
+
+        elif obj['class'] == 'LineageGraphVersion':
+            gev = LineageGraphVersion()
+            gev.sourceKey = obj['sourceKey']
+            gev.lineageGraphId = obj['lineageGraphId']
+            gev.lineageEdgeVersionIds = obj['lineageEdgeVersionIds']
+            gev.lineageGraphVersionId = obj['lineageGraphVersionId']
+            if 'tags' in obj:
+                gev.tags = obj['tags']
+            if 'structureVersionId' in obj:
+                gev.structureVersionId = obj['structureVersionId']
+            if 'reference' in obj:
+                gev.reference = obj['reference']
+            if 'referenceParameters' in obj:
+                gev.referenceParameters = obj['referenceParameters']
+            if 'parentIds' in obj:
+                gev.parentIds = obj['parentIds']
+
+            if gev.sourceKey in self.graph.lineageGraphVersions:
+                self.graph.lineageGraphVersions[gev.sourceKey].append(gev)
+            else:
+                self.graph.lineageGraphVersions[gev.sourceKey] = [gev, ]
+            self.graph.lineageGraphVersions[gev.lineageGraphVersionId] = gev
+            self.graph.ids |= {gev.lineageGraphVersionId, }
+        else:
+            raise NotImplementedError()
+
+    def load(self):
+        if self.graph.ids:
+            return
+        os.chdir('../')
+
+        def is_number(s):
+            try:
+                float(s)
+                return True
+            except ValueError:
+                return False
+
+        listdir = [x for x in filter(is_number, os.listdir())]
+
+        prevDir = str(len(listdir) - 1)
+        os.chdir(prevDir)
+        for _, _, filenames in os.walk('.'):
+            for filename in filenames:
+                filename = filename.split('.')
+                if filename[-1] == 'json':
+                    filename = '.'.join(filename)
+                    with open(filename, 'r') as f:
+                        self.to_class(json.loads(f.read()))
+        os.chdir('../' + str(int(prevDir) + 1))
+
+
+class GroundImplementation(GroundAPI):
+    def __init__(self, host='localhost', port=9000):
+        self.host = host
+        self.port = str(port)
+        self.url = "http://" + self.host + ":" + self.port
+
+
+class GroundClient(GroundAPI):
+    def __new__(*args, **kwargs):
+        if args and args[1].strip().lower() == 'git':
+            return GitImplementation(**kwargs)
+        elif args and args[1].strip().lower() == 'ground':
+            # EXAMPLE CALL: GroundClient('ground', host='localhost', port=9000)
+            return GroundImplementation(**kwargs)
+        else:
+            raise ValueError(
+                "Backend not supported. Please choose 'git' or 'ground'")

--- a/test_ground.py
+++ b/test_ground.py
@@ -1,0 +1,1926 @@
+import unittest
+import ground
+
+
+class GroundTest(unittest.TestCase):
+    def test_node_attr(self):
+        node = ground.Node('testSourceKey', 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(node.sourceKey, "node attribute 'sourceKey' is None")
+        self.assertEqual(node.sourceKey, 'testSourceKey', "node attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(node.sourceKey))
+        self.assertIsNotNone(node.name, "node attribute 'name' is None")
+        self.assertEqual(node.name, 'testName', "node attribute 'name', Expected: testName, "
+                                                "Actual: " + str(node.name))
+        self.assertIsNotNone(node.tags, "node attribute 'tags' is None")
+        self.assertEqual(node.tags, {'testKey': 'testValue'},
+                         "node attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(node.tags))
+        node_json = node.to_json()
+        self.assertEqual(node_json, '{"nodeId": null, "class": "Node", "sourceKey": "testSourceKey", '
+                                    '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_edge_attr(self):
+        edge = ground.Edge('testSourceKey', 0, 1, 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(edge.sourceKey, "edge attribute 'sourceKey' is None")
+        self.assertEqual(edge.sourceKey, 'testSourceKey', "edge attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(edge.sourceKey))
+        self.assertIsNotNone(edge.fromNodeId, "edge attribute 'fromNodeId' is None")
+        self.assertEqual(edge.fromNodeId, 0, "edge attribute 'fromNodeId', Expected: 0, "
+                                             "Actual: " + str(edge.fromNodeId))
+        self.assertIsNotNone(edge.toNodeId, "edge attribute 'toNodeId' is None")
+        self.assertEqual(edge.toNodeId, 1, "edge attribute 'toNodeId', Expected: 1, "
+                                           "Actual: " + str(edge.toNodeId))
+        self.assertIsNotNone(edge.name, "edge attribute 'name' is None")
+        self.assertEqual(edge.name, 'testName', "edge attribute 'name', Expected: testName, "
+                                                "Actual: " + str(edge.name))
+        self.assertIsNotNone(edge.tags, "edge attribute 'tags' is None")
+        self.assertEqual(edge.tags, {'testKey': 'testValue'},
+                         "edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(edge.tags))
+        edge_json = edge.to_json()
+        self.assertEqual(edge_json, '{"fromNodeId": 0, "name": "testName", "edgeId": null, '
+                                    '"tags": {"testKey": "testValue"}, "class": "Edge", '
+                                    '"toNodeId": 1, "sourceKey": "testSourceKey"}')
+
+    def test_graph_attr(self):
+        graph = ground.Graph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(graph.sourceKey, "graph attribute 'sourceKey' is None")
+        self.assertEqual(graph.sourceKey, 'testSourceKey', "graph attribute 'sourceKey', "
+                                                           "Expected: testSourceKey, Actual: " + str(graph.sourceKey))
+        self.assertIsNotNone(graph.name, "graph attribute 'name' is None")
+        self.assertEqual(graph.name, 'testName', "graph attribute 'name', Expected: testName, "
+                                                 "Actual: " + str(graph.name))
+        self.assertIsNotNone(graph.tags, "graph attribute 'tags' is None")
+        self.assertEqual(graph.tags, {'testKey': 'testValue'},
+                         "graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(graph.tags))
+        self.assertEqual(graph.nodes, {})
+        self.assertEqual(graph.nodeVersions, {})
+        self.assertEqual(graph.edges, {})
+        self.assertEqual(graph.edgeVersions, {})
+        self.assertEqual(graph.graphs, {})
+        self.assertEqual(graph.graphVersions, {})
+        self.assertEqual(graph.structures, {})
+        self.assertEqual(graph.structureVersions, {})
+        self.assertEqual(graph.lineageEdges, {})
+        self.assertEqual(graph.lineageEdgeVersions, {})
+        self.assertEqual(graph.lineageGraphs, {})
+        self.assertEqual(graph.lineageGraphVersions, {})
+        self.assertEqual(graph.ids, set([]))
+        for i in range(100):
+            testId = graph.gen_id()
+            self.assertIn(testId, graph.ids)
+            self.assertNotIn(len(graph.ids), graph.ids)
+        graph_json = graph.to_json()
+        self.assertEqual(graph_json, '{"class": "Graph", "graphId": null, "sourceKey": "testSourceKey", '
+                                     '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_structure_attr(self):
+        structure = ground.Structure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(structure.sourceKey, "structure attribute 'sourceKey' is None")
+        self.assertEqual(structure.sourceKey, 'testSourceKey', "structure attribute 'sourceKey', "
+                                                               "Expected: testSourceKey, "
+                                                               "Actual: " + str(structure.sourceKey))
+        self.assertIsNotNone(structure.name, "structure attribute 'name' is None")
+        self.assertEqual(structure.name, 'testName', "structure attribute 'name', Expected: testName, "
+                                                     "Actual: " + str(structure.name))
+        self.assertIsNotNone(structure.tags, "structure attribute 'tags' is None")
+        self.assertEqual(structure.tags, {'testKey': 'testValue'},
+                         "structure attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(structure.tags))
+        structure_json = structure.to_json()
+        self.assertEqual(structure_json, '{"class": "Structure", "structureId": null, "sourceKey": "testSourceKey", '
+                                         '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_lineage_edge_attr(self):
+        lineage_edge = ground.LineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(lineage_edge.sourceKey, "lineage_edge attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge.sourceKey, 'testSourceKey', "lineage_edge attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(lineage_edge.sourceKey))
+        self.assertIsNotNone(lineage_edge.name, "lineage_edge attribute 'name' is None")
+        self.assertEqual(lineage_edge.name, 'testName', "lineage_edge attribute 'name', Expected: testName, "
+                                                        "Actual: " + str(lineage_edge.name))
+        self.assertIsNotNone(lineage_edge.tags, "lineage_edge attribute 'tags' is None")
+        self.assertEqual(lineage_edge.tags, {'testKey': 'testValue'},
+                         "lineage_edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge.tags))
+        lineage_edge_json = lineage_edge.to_json()
+        self.assertEqual(lineage_edge_json, '{"class": "LineageEdge", "tags": {"testKey": "testValue"}, '
+                                            '"sourceKey": "testSourceKey", "lineageEdgeId": null, "name": "testName"}')
+
+    def test_lineage_graph_attr(self):
+        lineage_graph = ground.LineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        self.assertIsNotNone(lineage_graph.sourceKey, "lineage_graph attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph.sourceKey, 'testSourceKey', "lineage_graph attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(lineage_graph.sourceKey))
+        self.assertIsNotNone(lineage_graph.name, "lineage_graph attribute 'name' is None")
+        self.assertEqual(lineage_graph.name, 'testName', "lineage_graph attribute 'name', Expected: testName, "
+                                                         "Actual: " + str(lineage_graph.name))
+        self.assertIsNotNone(lineage_graph.tags, "lineage_graph attribute 'tags' is None")
+        self.assertEqual(lineage_graph.tags, {'testKey': 'testValue'},
+                         "lineage_graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph.tags))
+        lineage_graph_json = lineage_graph.to_json()
+        self.assertEqual(lineage_graph_json, '{"lineageGraphId": null, "class": "LineageGraph", '
+                                             '"tags": {"testKey": "testValue"}, '
+                                             '"sourceKey": "testSourceKey", "name": "testName"}')
+
+    def test_node_minimum(self):
+        node = ground.Node('testSourceKey')
+        self.assertIsNotNone(node.sourceKey, "node attribute 'sourceKey' is None")
+        self.assertEqual(node.sourceKey, 'testSourceKey', "node attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(node.sourceKey))
+        self.assertIsNone(node.name, "node attribute 'name' is not None, Value: " + str(node.name))
+        self.assertIsNone(node.tags, "node attribute 'tags' is not None, Value: " + str(node.tags))
+
+    def test_edge_minimum(self):
+        edge = ground.Edge('testSourceKey', 0, 1)
+        self.assertIsNotNone(edge.sourceKey, "edge attribute 'sourceKey' is None")
+        self.assertEqual(edge.sourceKey, 'testSourceKey', "edge attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(edge.sourceKey))
+        self.assertIsNotNone(edge.fromNodeId, "edge attribute 'fromNodeId' is None")
+        self.assertEqual(edge.fromNodeId, 0, "edge attribute 'fromNodeId', Expected: 0, "
+                                             "Actual: " + str(edge.fromNodeId))
+        self.assertIsNotNone(edge.toNodeId, "edge attribute 'toNodeId' is None")
+        self.assertEqual(edge.toNodeId, 1, "edge attribute 'toNodeId', Expected: 1, "
+                                           "Actual: " + str(edge.toNodeId))
+        self.assertIsNone(edge.name, "edge attribute 'name' is not None, Value: " + str(edge.name))
+        self.assertIsNone(edge.tags, "edge attribute 'tags' is not None, Value: " + str(edge.tags))
+
+    def test_graph_minimum(self):
+        graph = ground.Graph('testSourceKey')
+        self.assertIsNotNone(graph.sourceKey, "graph attribute 'sourceKey' is None")
+        self.assertEqual(graph.sourceKey, 'testSourceKey', "graph attribute 'sourceKey', "
+                                                           "Expected: testSourceKey, Actual: " + str(graph.sourceKey))
+        self.assertIsNone(graph.name, "graph attribute 'name' is not None, Value: " + str(graph.name))
+        self.assertIsNone(graph.tags, "graph attribute 'tags' is not None, Value: " + str(graph.tags))
+        self.assertEqual(graph.nodes, {})
+        self.assertEqual(graph.nodeVersions, {})
+        self.assertEqual(graph.edges, {})
+        self.assertEqual(graph.edgeVersions, {})
+        self.assertEqual(graph.graphs, {})
+        self.assertEqual(graph.graphVersions, {})
+        self.assertEqual(graph.structures, {})
+        self.assertEqual(graph.structureVersions, {})
+        self.assertEqual(graph.lineageEdges, {})
+        self.assertEqual(graph.lineageEdgeVersions, {})
+        self.assertEqual(graph.lineageGraphs, {})
+        self.assertEqual(graph.lineageGraphVersions, {})
+        self.assertEqual(graph.ids, set([]))
+        for i in range(100):
+            testId = graph.gen_id()
+            self.assertIn(testId, graph.ids)
+            self.assertNotIn(len(graph.ids), graph.ids)
+
+    def test_structure_minimum(self):
+        structure = ground.Structure('testSourceKey')
+        self.assertIsNotNone(structure.sourceKey, "structure attribute 'sourceKey' is None")
+        self.assertEqual(structure.sourceKey, 'testSourceKey', "structure attribute 'sourceKey', "
+                                                               "Expected: testSourceKey, "
+                                                               "Actual: " + str(structure.sourceKey))
+        self.assertIsNone(structure.name, "structure attribute 'name' is not None, Value: " + str(structure.name))
+        self.assertIsNone(structure.tags, "structure attribute 'tags' is not None, Value: " + str(structure.tags))
+
+    def test_lineage_edge_minimum(self):
+        lineage_edge = ground.LineageEdge('testSourceKey')
+        self.assertIsNotNone(lineage_edge.sourceKey, "lineage_edge attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge.sourceKey, 'testSourceKey', "lineage_edge attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(lineage_edge.sourceKey))
+        self.assertIsNone(lineage_edge.name, "lineage_edge attribute 'name' is not None, "
+                                             "Value: " + str(lineage_edge.name))
+        self.assertIsNone(lineage_edge.tags, "lineage_edge attribute 'tags' is not None, "
+                                             "Value: " + str(lineage_edge.tags))
+
+    def test_lineage_graph_minimum(self):
+        lineage_graph = ground.LineageGraph('testSourceKey')
+        self.assertIsNotNone(lineage_graph.sourceKey, "lineage_graph attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph.sourceKey, 'testSourceKey', "lineage_graph attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(lineage_graph.sourceKey))
+        self.assertIsNone(lineage_graph.name, "lineage_graph attribute 'name' is not None, "
+                                              "Value: " + str(lineage_graph.name))
+        self.assertIsNone(lineage_graph.tags, "lineage_graph attribute 'tags' is not None, "
+                                              "Value: " + str(lineage_graph.tags))
+
+    def test_node_version_attr(self):
+        node = ground.Node('testSourceKey', 'testName', {'testKey': 'testValue'})
+        node.nodeId = 0
+        node_version = ground.NodeVersion(node, "testReference", "testReferenceParameters",
+                                          {'testKey': 'testValue'}, 1, [2, 3])
+        self.assertIsNotNone(node_version.sourceKey, "node_version attribute 'sourceKey' is None")
+        self.assertEqual(node_version.sourceKey, 'testSourceKey', "node_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(node_version.sourceKey))
+        self.assertIsNotNone(node_version.nodeId, "node_version attribute 'nodeId' is None")
+        self.assertEqual(node_version.nodeId, 0, "node_version attribute 'nodeId', "
+                                                 "Expected: 0, Actual: " + str(node_version.nodeId))
+        self.assertIsNotNone(node_version.reference, "node_version attribute 'reference' is None")
+        self.assertEqual(node_version.reference, "testReference", "node_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(node_version.reference))
+        self.assertIsNotNone(node_version.referenceParameters, "node_version attribute 'referenceParameters' is None")
+        self.assertEqual(node_version.referenceParameters, "testReferenceParameters", "node_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            node_version.referenceParameters))
+        self.assertIsNotNone(node_version.tags, "node_version attribute 'tags' is None")
+        self.assertEqual(node_version.tags,
+                         {'testKey': 'testValue'},
+                         "node_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(node_version.tags))
+        self.assertIsNotNone(node_version.structureVersionId, "node_version attribute 'structureVersionId' is None")
+        self.assertEqual(node_version.structureVersionId, 1, "node_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(node_version.structureVersionId))
+        self.assertIsNotNone(node_version.parentIds, "node_version attribute 'parentIds' is None")
+        self.assertEqual(node_version.parentIds, [2, 3], "node_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(node_version.parentIds))
+        node_version_json = node_version.to_json()
+        self.assertEqual(node_version_json, '{"nodeVersionId": null, "reference": "testReference", '
+                                            '"tags": {"testKey": "testValue"}, '
+                                            '"referenceParameters": "testReferenceParameters", "class": "NodeVersion", '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"sourceKey": "testSourceKey", "nodeId": 0}')
+
+    def test_edge_version_attr(self):
+        edge = ground.Edge('testSourceKey', 0, 10, 'testName', {'testKey': 'testValue'})
+        edge.edgeId = 0
+        edge_version = ground.EdgeVersion(edge, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                          {'testKey': 'testValue'}, 1, [2, 3])
+        self.assertIsNotNone(edge_version.sourceKey, "edge_version attribute 'sourceKey' is None")
+        self.assertEqual(edge_version.sourceKey, 'testSourceKey', "edge_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(edge_version.sourceKey))
+        self.assertIsNotNone(edge_version.fromNodeId, "edge_version attribute 'fromNodeId' is None")
+        self.assertEqual(edge_version.fromNodeId, 0, "edge_version attribute 'fromNodeId', "
+                                                     "Expected: 0, Actual: " + str(edge_version.fromNodeId))
+        self.assertIsNotNone(edge_version.toNodeId, "edge_version attribute 'toNodeId' is None")
+        self.assertEqual(edge_version.toNodeId, 10, "edge_version attribute 'toNodeId', "
+                                                    "Expected: 10, Actual: " + str(edge_version.toNodeId))
+        self.assertIsNotNone(edge_version.edgeId, "edge_version attribute 'edgeId' is None")
+        self.assertEqual(edge_version.edgeId, 0, "edge_version attribute 'edgeId', "
+                                                 "Expected: 0, Actual: " + str(edge_version.edgeId))
+        self.assertIsNotNone(edge_version.toNodeVersionStartId, "edge_version attribute 'toNodeVersionStartId' is None")
+        self.assertEqual(edge_version.toNodeVersionStartId, 4, "edge_version attribute 'toNodeVersionStartId', "
+                                                               "Expected: 4, Actual: " + str(
+            edge_version.toNodeVersionStartId))
+        self.assertIsNotNone(edge_version.fromNodeVersionStartId, "edge_version attribute 'fromNodeVersionStartId' "
+                                                                  "is None")
+        self.assertEqual(edge_version.fromNodeVersionStartId, 5, "edge_version attribute 'fromNodeVersionStartId', "
+                                                                 "Expected: 5, Actual: " + str(
+            edge_version.fromNodeVersionStartId))
+        self.assertIsNotNone(edge_version.toNodeVersionEndId, "edge_version attribute 'toNodeVersionEndId' is None")
+        self.assertEqual(edge_version.toNodeVersionEndId, 6, "edge_version attribute 'toNodeVersionEndId', "
+                                                             "Expected: 6, Actual: " + str(
+            edge_version.toNodeVersionEndId))
+        self.assertIsNotNone(edge_version.fromNodeVersionEndId, "edge_version attribute 'fromNodeVersionEndId' is None")
+        self.assertEqual(edge_version.fromNodeVersionEndId, 7, "edge_version attribute 'fromNodeVersionEndId', "
+                                                               "Expected: 7, Actual: " + str(
+            edge_version.fromNodeVersionEndId))
+        self.assertIsNotNone(edge_version.reference, "edge_version attribute 'reference' is None")
+        self.assertEqual(edge_version.reference, "testReference", "edge_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(edge_version.reference))
+        self.assertIsNotNone(edge_version.referenceParameters, "edge_version attribute 'referenceParameters' is None")
+        self.assertEqual(edge_version.referenceParameters, "testReferenceParameters", "edge_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            edge_version.referenceParameters))
+        self.assertIsNotNone(edge_version.tags, "edge_version attribute 'tags' is None")
+        self.assertEqual(edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(edge_version.tags))
+        self.assertIsNotNone(edge_version.structureVersionId, "edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(edge_version.structureVersionId, 1, "edge_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(edge_version.structureVersionId))
+        self.assertIsNotNone(edge_version.parentIds, "edge_version attribute 'parentIds' is None")
+        self.assertEqual(edge_version.parentIds, [2, 3], "edge_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(edge_version.parentIds))
+        edge_version_json = edge_version.to_json()
+        self.assertEqual(edge_version_json, '{"toNodeVersionStartId": 4, "toNodeVersionEndId": 6, '
+                                            '"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                            '"edgeVersionId": null, "referenceParameters": "testReferenceParameters", '
+                                            '"class": "EdgeVersion", "fromNodeId": 0, "edgeId": 0, '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"fromNodeVersionStartId": 5, "toNodeId": 10, '
+                                            '"fromNodeVersionEndId": 7, "sourceKey": "testSourceKey"}')
+
+    def test_graph_version_attr(self):
+        graph = ground.Graph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        graph.graphId = 0
+        graph_version = ground.GraphVersion(graph, [4, 5, 6], "testReference", "testReferenceParameters",
+                                            {'testKey': 'testValue'}, 1, [2, 3])
+        self.assertIsNotNone(graph_version.sourceKey, "graph_version attribute 'sourceKey' is None")
+        self.assertEqual(graph_version.sourceKey, 'testSourceKey', "graph_version attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(graph_version.sourceKey))
+        self.assertIsNotNone(graph_version.graphId, "graph_version attribute 'graphId' is None")
+        self.assertEqual(graph_version.graphId, 0, "graph_version attribute 'graphId', "
+                                                   "Expected: 0, Actual: " + str(graph_version.graphId))
+        self.assertIsNotNone(graph_version.edgeVersionIds, "graph_version attribute 'edgeVersionIds' is None")
+        self.assertEqual(graph_version.edgeVersionIds, [4, 5, 6], "graph_version attribute 'edgeVersionIds', "
+                                                                  "Expected: [4, 5, 6], "
+                                                                  "Actual: " + str(graph_version.edgeVersionIds))
+        self.assertIsNotNone(graph_version.reference, "graph_version attribute 'reference' is None")
+        self.assertEqual(graph_version.reference, "testReference", "graph_version attribute 'reference', "
+                                                                   "Expected: testReference, "
+                                                                   "Actual: " + str(graph_version.reference))
+        self.assertIsNotNone(graph_version.referenceParameters, "graph_version attribute 'referenceParameters' is None")
+        self.assertEqual(graph_version.referenceParameters, "testReferenceParameters", "graph_version attribute "
+                                                                                       "'referenceParameters', "
+                                                                                       "Expected: testReferenceParameters, "
+                                                                                       "Actual: " + str(
+            graph_version.referenceParameters))
+        self.assertIsNotNone(graph_version.tags, "graph_version attribute 'tags' is None")
+        self.assertEqual(graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(graph_version.tags))
+        self.assertIsNotNone(graph_version.structureVersionId, "graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(graph_version.structureVersionId, 1, "graph_version attribute 'structureVersionId', "
+                                                              "Expected: 1, "
+                                                              "Actual: " + str(graph_version.structureVersionId))
+        self.assertIsNotNone(graph_version.parentIds, "graph_version attribute 'parentIds' is None")
+        self.assertEqual(graph_version.parentIds, [2, 3], "graph_version attribute 'parentIds', "
+                                                          "Expected: [2, 3], "
+                                                          "Actual: " + str(graph_version.parentIds))
+        graph_version_json = graph_version.to_json()
+        self.assertEqual(graph_version_json, '{"parentIds": [2, 3], "graphId": 0, "reference": "testReference", '
+                                             '"edgeVersionIds": [4, 5, 6], '
+                                             '"referenceParameters": "testReferenceParameters", '
+                                             '"graphVersionId": null, "tags": {"testKey": "testValue"}, '
+                                             '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                             '"class": "GraphVersion"}')
+
+    def test_structure_version_attr(self):
+        structure = ground.Structure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        structure.structureId = 0
+        structure_version = ground.StructureVersion(structure, {'testKey': 'testValue'}, [2, 3])
+        self.assertIsNotNone(structure_version.sourceKey, "structure_version attribute 'sourceKey' is None")
+        self.assertEqual(structure_version.sourceKey, 'testSourceKey', "structure_version attribute 'sourceKey', "
+                                                                       "Expected: testSourceKey, "
+                                                                       "Actual: " + str(structure_version.sourceKey))
+        self.assertIsNotNone(structure_version.structureId, "structure_version attribute 'structureId' is None")
+        self.assertEqual(structure_version.structureId, 0, "structure_version attribute 'structureId', "
+                                                           "Expected: 0, Actual: " + str(structure_version.structureId))
+        self.assertIsNotNone(structure_version.attributes, "structure_version attribute 'attributes' is None")
+        self.assertEqual(structure_version.attributes, {'testKey': 'testValue'}, "structure_version "
+                                                                                 "attribute 'attributes', "
+                                                                                 "Expected: , " + str(
+            {'testKey': 'testValue'}) +
+                         ", Actual: " + str(structure_version.attributes))
+        self.assertIsNotNone(structure_version.parentIds, "structure_version attribute 'parentIds' is None")
+        self.assertEqual(structure_version.parentIds, [2, 3], "structure_version attribute 'parentIds', "
+                                                              "Expected: [2, 3], "
+                                                              "Actual: " + str(structure_version.parentIds))
+        structure_version_json = structure_version.to_json()
+        self.assertEqual(structure_version_json, '{"parentIds": [2, 3], "structureId": 0, "structureVersionId": null, '
+                                                 '"sourceKey": "testSourceKey", '
+                                                 '"attributes": {"testKey": "testValue"}, '
+                                                 '"class": "StructureVersion"}')
+
+    def test_lineage_edge_version_attr(self):
+        lineage_edge = ground.LineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_edge.lineageEdgeId = 0
+        lineage_edge_version = ground.LineageEdgeVersion(lineage_edge, 5, 4, "testReference", "testReferenceParameters",
+                                                         {'testKey': 'testValue'}, 1, [2, 3])
+        self.assertIsNotNone(lineage_edge_version.sourceKey, "lineage_edge_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge_version.sourceKey, 'testSourceKey', "lineage_edge_version attribute 'sourceKey', "
+                                                                          "Expected: testSourceKey, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.sourceKey))
+        self.assertIsNotNone(lineage_edge_version.lineageEdgeId, "lineage_edge_version attribute "
+                                                                 "'lineageEdgeId' is None")
+        self.assertEqual(lineage_edge_version.lineageEdgeId, 0, "lineage_edge_version attribute 'lineageEdgeId', "
+                                                                "Expected: 0, Actual: " + str(
+            lineage_edge_version.lineageEdgeId))
+        self.assertIsNotNone(lineage_edge_version.fromRichVersionId, "lineage_edge_version attribute "
+                                                                     "'fromRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.fromRichVersionId, 4,
+                         "lineage_edge_version attribute 'fromRichVersionId', "
+                         "Expected: 4, Actual: " + str(lineage_edge_version.fromRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.toRichVersionId, "lineage_edge_version attribute "
+                                                                   "'toRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.toRichVersionId, 5, "lineage_edge_version attribute 'toRichVersionId', "
+                                                                  "Expected: 5, Actual: " + str(
+            lineage_edge_version.toRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.reference, "lineage_edge_version attribute 'reference' is None")
+        self.assertEqual(lineage_edge_version.reference, "testReference", "lineage_edge_version attribute 'reference', "
+                                                                          "Expected: testReference, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.reference))
+        self.assertIsNotNone(lineage_edge_version.referenceParameters, "lineage_edge_version attribute "
+                                                                       "'referenceParameters' is None")
+        self.assertEqual(lineage_edge_version.referenceParameters, "testReferenceParameters",
+                         "lineage_edge_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_edge_version.referenceParameters))
+        self.assertIsNotNone(lineage_edge_version.tags, "lineage_edge_version attribute 'tags' is None")
+        self.assertEqual(lineage_edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge_version.tags))
+        self.assertIsNotNone(lineage_edge_version.structureVersionId,
+                             "lineage_edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_edge_version.structureVersionId, 1,
+                         "lineage_edge_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_edge_version.structureVersionId))
+        self.assertIsNotNone(lineage_edge_version.parentIds, "lineage_edge_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_edge_version.parentIds, [2, 3], "lineage_edge_version attribute 'parentIds', "
+                                                                 "Expected: [2, 3], "
+                                                                 "Actual: " + str(lineage_edge_version.parentIds))
+        lineage_edge_version_json = lineage_edge_version.to_json()
+        self.assertEqual(lineage_edge_version_json, '{"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                                    '"lineageEdgeVersionId": null, '
+                                                    '"referenceParameters": "testReferenceParameters", '
+                                                    '"fromRichVersionId": 4, "class": "LineageEdgeVersion", '
+                                                    '"parentIds": [2, 3], "structureVersionId": 1, '
+                                                    '"toRichVersionId": 5, "lineageEdgeId": 0, '
+                                                    '"sourceKey": "testSourceKey"}')
+
+    def test_lineage_graph_version_attr(self):
+        lineage_graph = ground.LineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_graph.lineageGraphId = 0
+        lineage_graph_version = ground.LineageGraphVersion(lineage_graph, [5, 4], "testReference",
+                                                           "testReferenceParameters",
+                                                           {'testKey': 'testValue'}, 1, [2, 3])
+        self.assertIsNotNone(lineage_graph_version.sourceKey, "lineage_graph_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph_version.sourceKey, 'testSourceKey',
+                         "lineage_graph_version attribute 'sourceKey', "
+                         "Expected: testSourceKey, "
+                         "Actual: " + str(
+                             lineage_graph_version.sourceKey))
+        self.assertIsNotNone(lineage_graph_version.lineageGraphId, "lineage_graph_version attribute "
+                                                                   "'lineageGraphId' is None")
+        self.assertEqual(lineage_graph_version.lineageGraphId, 0, "lineage_graph_version attribute 'lineageGraphId', "
+                                                                  "Expected: 0, Actual: " + str(
+            lineage_graph_version.lineageGraphId))
+        self.assertIsNotNone(lineage_graph_version.lineageEdgeVersionIds, "lineage_graph_version attribute "
+                                                                          "'lineageEdgeVersionIds' is None")
+        self.assertEqual(lineage_graph_version.lineageEdgeVersionIds, [5, 4],
+                         "lineage_graph_version attribute 'lineageEdgeVersionIds', "
+                         "Expected: [5, 4], Actual: " + str(lineage_graph_version.lineageEdgeVersionIds))
+        self.assertIsNotNone(lineage_graph_version.reference, "lineage_graph_version attribute 'reference' is None")
+        self.assertEqual(lineage_graph_version.reference, "testReference",
+                         "lineage_graph_version attribute 'reference', "
+                         "Expected: testReference, "
+                         "Actual: " + str(
+                             lineage_graph_version.reference))
+        self.assertIsNotNone(lineage_graph_version.referenceParameters, "lineage_graph_version attribute "
+                                                                        "'referenceParameters' is None")
+        self.assertEqual(lineage_graph_version.referenceParameters, "testReferenceParameters",
+                         "lineage_graph_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_graph_version.referenceParameters))
+        self.assertIsNotNone(lineage_graph_version.tags, "lineage_graph_version attribute 'tags' is None")
+        self.assertEqual(lineage_graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph_version.tags))
+        self.assertIsNotNone(lineage_graph_version.structureVersionId,
+                             "lineage_graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_graph_version.structureVersionId, 1,
+                         "lineage_graph_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_graph_version.structureVersionId))
+        self.assertIsNotNone(lineage_graph_version.parentIds, "lineage_graph_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_graph_version.parentIds, [2, 3], "lineage_graph_version attribute 'parentIds', "
+                                                                  "Expected: [2, 3], "
+                                                                  "Actual: " + str(lineage_graph_version.parentIds))
+        lineage_graph_version_json = lineage_graph_version.to_json()
+        self.assertEqual(lineage_graph_version_json, '{"lineageGraphId": 0, "lineageGraphVersionId": null, '
+                                                     '"parentIds": [2, 3], "reference": "testReference", '
+                                                     '"tags": {"testKey": "testValue"}, '
+                                                     '"referenceParameters": "testReferenceParameters", '
+                                                     '"lineageEdgeVersionIds": [5, 4], '
+                                                     '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                                     '"class": "LineageGraphVersion"}')
+
+    def test_node_version_minimum(self):
+        node = ground.Node('testSourceKey', 'testName', {'testKey': 'testValue'})
+        node.nodeId = 0
+        node_version = ground.NodeVersion(node)
+        self.assertIsNotNone(node_version.sourceKey, "node_version attribute 'sourceKey' is None")
+        self.assertEqual(node_version.sourceKey, 'testSourceKey', "node_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(node_version.sourceKey))
+        self.assertIsNotNone(node_version.nodeId, "node_version attribute 'nodeId' is None")
+        self.assertEqual(node_version.nodeId, 0, "node_version attribute 'nodeId', "
+                                                 "Expected: 0, Actual: " + str(node_version.nodeId))
+        self.assertIsNone(node_version.reference, "node_version attribute 'reference' is not None")
+        self.assertIsNone(node_version.referenceParameters, "node_version attribute 'referenceParameters' is not None")
+        self.assertIsNone(node_version.tags, "node_version attribute 'tags' is not None")
+        self.assertIsNone(node_version.structureVersionId, "node_version attribute 'structureVersionId' is not None")
+        self.assertIsNone(node_version.parentIds, "node_version attribute 'parentIds' is not None")
+
+    def test_edge_version_minimum(self):
+        edge = ground.Edge('testSourceKey', 0, 10)
+        edge.edgeId = 0
+        edge_version = ground.EdgeVersion(edge, 4, 5)
+        self.assertIsNotNone(edge_version.sourceKey, "edge_version attribute 'sourceKey' is None")
+        self.assertEqual(edge_version.sourceKey, 'testSourceKey', "edge_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(edge_version.sourceKey))
+        self.assertIsNotNone(edge_version.fromNodeId, "edge_version attribute 'fromNodeId' is None")
+        self.assertEqual(edge_version.fromNodeId, 0, "edge_version attribute 'fromNodeId', "
+                                                     "Expected: 0, Actual: " + str(edge_version.fromNodeId))
+        self.assertIsNotNone(edge_version.toNodeId, "edge_version attribute 'toNodeId' is None")
+        self.assertEqual(edge_version.toNodeId, 10, "edge_version attribute 'toNodeId', "
+                                                    "Expected: 10, Actual: " + str(edge_version.toNodeId))
+        self.assertIsNotNone(edge_version.edgeId, "edge_version attribute 'edgeId' is None")
+        self.assertEqual(edge_version.edgeId, 0, "edge_version attribute 'edgeId', "
+                                                 "Expected: 0, Actual: " + str(edge_version.edgeId))
+        self.assertIsNotNone(edge_version.toNodeVersionStartId, "edge_version attribute 'toNodeVersionStartId' is None")
+        self.assertEqual(edge_version.toNodeVersionStartId, 4, "edge_version attribute 'toNodeVersionStartId', "
+                                                               "Expected: 4, Actual: " + str(
+            edge_version.toNodeVersionStartId))
+        self.assertIsNotNone(edge_version.fromNodeVersionStartId, "edge_version attribute 'fromNodeVersionStartId' "
+                                                                  "is None")
+        self.assertEqual(edge_version.fromNodeVersionStartId, 5, "edge_version attribute 'fromNodeVersionStartId', "
+                                                                 "Expected: 5, Actual: " + str(
+            edge_version.fromNodeVersionStartId))
+        self.assertIsNone(edge_version.toNodeVersionEndId, "edge_version attribute 'toNodeVersionEndId' is not None")
+        self.assertIsNone(edge_version.fromNodeVersionEndId, "edge_version attribute 'fromNodeVersionEndId' "
+                                                             "is not None")
+        self.assertIsNone(edge_version.reference, "edge_version attribute 'reference' is not None")
+        self.assertIsNone(edge_version.referenceParameters, "edge_version attribute 'referenceParameters' is not None")
+        self.assertIsNone(edge_version.tags, "edge_version attribute 'tags' is not None")
+        self.assertIsNone(edge_version.structureVersionId, "edge_version attribute 'structureVersionId' is not None")
+        self.assertIsNone(edge_version.parentIds, "edge_version attribute 'parentIds' is not None")
+
+    def test_graph_version_minimum(self):
+        graph = ground.Graph('testSourceKey')
+        graph.graphId = 0
+        graph_version = ground.GraphVersion(graph, [4, 5, 6])
+        self.assertIsNotNone(graph_version.sourceKey, "graph_version attribute 'sourceKey' is None")
+        self.assertEqual(graph_version.sourceKey, 'testSourceKey', "graph_version attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(graph_version.sourceKey))
+        self.assertIsNotNone(graph_version.graphId, "graph_version attribute 'graphId' is None")
+        self.assertEqual(graph_version.graphId, 0, "graph_version attribute 'graphId', "
+                                                   "Expected: 0, Actual: " + str(graph_version.graphId))
+        self.assertIsNotNone(graph_version.edgeVersionIds, "graph_version attribute 'edgeVersionIds' is None")
+        self.assertEqual(graph_version.edgeVersionIds, [4, 5, 6], "graph_version attribute 'edgeVersionIds', "
+                                                                  "Expected: [4, 5, 6], "
+                                                                  "Actual: " + str(graph_version.edgeVersionIds))
+        self.assertIsNone(graph_version.reference, "graph_version attribute 'reference' is not None")
+        self.assertIsNone(graph_version.referenceParameters, "graph_version attribute 'referenceParameters' "
+                                                             "is not None")
+        self.assertIsNone(graph_version.tags, "graph_version attribute 'tags' is not None")
+        self.assertIsNone(graph_version.structureVersionId, "graph_version attribute 'structureVersionId' is not None")
+        self.assertIsNone(graph_version.parentIds, "graph_version attribute 'parentIds' is not None")
+
+    def test_structure_version_minimum(self):
+        structure = ground.Structure('testSourceKey')
+        structure.structureId = 0
+        structure_version = ground.StructureVersion(structure, {'testKey': 'testValue'})
+        self.assertIsNotNone(structure_version.sourceKey, "structure_version attribute 'sourceKey' is None")
+        self.assertEqual(structure_version.sourceKey, 'testSourceKey', "structure_version attribute 'sourceKey', "
+                                                                       "Expected: testSourceKey, "
+                                                                       "Actual: " + str(structure_version.sourceKey))
+        self.assertIsNotNone(structure_version.structureId, "structure_version attribute 'structureId' is None")
+        self.assertEqual(structure_version.structureId, 0, "structure_version attribute 'structureId', "
+                                                           "Expected: 0, Actual: " + str(structure_version.structureId))
+        self.assertIsNotNone(structure_version.attributes, "structure_version attribute 'attributes' is None")
+        self.assertEqual(structure_version.attributes, {'testKey': 'testValue'}, "structure_version "
+                                                                                 "attribute 'attributes', "
+                                                                                 "Expected: , " + str(
+            {'testKey': 'testValue'}) +
+                         ", Actual: " + str(structure_version.attributes))
+        self.assertIsNone(structure_version.parentIds, "structure_version attribute 'parentIds' is not None")
+
+    def test_lineage_edge_version_minimum(self):
+        lineage_edge = ground.LineageEdge('testSourceKey')
+        lineage_edge.lineageEdgeId = 0
+        lineage_edge_version = ground.LineageEdgeVersion(lineage_edge, 5, 4)
+        self.assertIsNotNone(lineage_edge_version.sourceKey, "lineage_edge_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge_version.sourceKey, 'testSourceKey', "lineage_edge_version attribute 'sourceKey', "
+                                                                          "Expected: testSourceKey, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.sourceKey))
+        self.assertIsNotNone(lineage_edge_version.lineageEdgeId, "lineage_edge_version attribute "
+                                                                 "'lineageEdgeId' is None")
+        self.assertEqual(lineage_edge_version.lineageEdgeId, 0, "lineage_edge_version attribute 'lineageEdgeId', "
+                                                                "Expected: 0, Actual: " + str(
+            lineage_edge_version.lineageEdgeId))
+        self.assertIsNotNone(lineage_edge_version.fromRichVersionId, "lineage_edge_version attribute "
+                                                                     "'fromRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.fromRichVersionId, 4,
+                         "lineage_edge_version attribute 'fromRichVersionId', "
+                         "Expected: 4, Actual: " + str(lineage_edge_version.fromRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.toRichVersionId, "lineage_edge_version attribute "
+                                                                   "'toRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.toRichVersionId, 5, "lineage_edge_version attribute 'toRichVersionId', "
+                                                                  "Expected: 5, Actual: " + str(
+            lineage_edge_version.toRichVersionId))
+        self.assertIsNone(lineage_edge_version.reference, "lineage_edge_version attribute 'reference' is not None")
+        self.assertIsNone(lineage_edge_version.referenceParameters, "lineage_edge_version attribute "
+                                                                    "'referenceParameters' is not None")
+        self.assertIsNone(lineage_edge_version.tags, "lineage_edge_version attribute 'tags' is not None")
+        self.assertIsNone(lineage_edge_version.structureVersionId,
+                          "lineage_edge_version attribute 'structureVersionId' is not None")
+        self.assertIsNone(lineage_edge_version.parentIds, "lineage_edge_version attribute 'parentIds' is not None")
+
+    def test_lineage_graph_version_minimum(self):
+        lineage_graph = ground.LineageGraph('testSourceKey')
+        lineage_graph.lineageGraphId = 0
+        lineage_graph_version = ground.LineageGraphVersion(lineage_graph, [5, 4])
+        self.assertIsNotNone(lineage_graph_version.sourceKey, "lineage_graph_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph_version.sourceKey, 'testSourceKey',
+                         "lineage_graph_version attribute 'sourceKey', "
+                         "Expected: testSourceKey, "
+                         "Actual: " + str(
+                             lineage_graph_version.sourceKey))
+        self.assertIsNotNone(lineage_graph_version.lineageGraphId, "lineage_graph_version attribute "
+                                                                   "'lineageGraphId' is None")
+        self.assertEqual(lineage_graph_version.lineageGraphId, 0, "lineage_graph_version attribute 'lineageGraphId', "
+                                                                  "Expected: 0, Actual: " + str(
+            lineage_graph_version.lineageGraphId))
+        self.assertIsNotNone(lineage_graph_version.lineageEdgeVersionIds, "lineage_graph_version attribute "
+                                                                          "'lineageEdgeVersionIds' is None")
+        self.assertEqual(lineage_graph_version.lineageEdgeVersionIds, [5, 4],
+                         "lineage_graph_version attribute 'lineageEdgeVersionIds', "
+                         "Expected: [5, 4], Actual: " + str(lineage_graph_version.lineageEdgeVersionIds))
+        self.assertIsNone(lineage_graph_version.reference, "lineage_graph_version attribute 'reference' is not None")
+        self.assertIsNone(lineage_graph_version.referenceParameters, "lineage_graph_version attribute "
+                                                                     "'referenceParameters' is not None")
+        self.assertIsNone(lineage_graph_version.tags, "lineage_graph_version attribute 'tags' is not None")
+        self.assertIsNone(lineage_graph_version.structureVersionId,
+                          "lineage_graph_version attribute 'structureVersionId' is not None")
+        self.assertIsNone(lineage_graph_version.parentIds, "lineage_graph_version attribute 'parentIds' is not None")
+
+    def test_git_create_node(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey', 'testName', {'testKey': 'testValue'})
+        node = git.graph.nodes[nodeId]
+        self.assertIsNotNone(node.sourceKey, "node attribute 'sourceKey' is None")
+        self.assertEqual(node.sourceKey, 'testSourceKey', "node attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(node.sourceKey))
+        self.assertIsNotNone(node.name, "node attribute 'name' is None")
+        self.assertEqual(node.name, 'testName', "node attribute 'name', Expected: testName, "
+                                                "Actual: " + str(node.name))
+        self.assertIsNotNone(node.tags, "node attribute 'tags' is None")
+        self.assertEqual(node.tags, {'testKey': 'testValue'},
+                         "node attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(node.tags))
+        node_json = node.to_json()
+        self.assertEqual(node_json, '{"nodeId": 0, "class": "Node", "sourceKey": "testSourceKey", '
+                                    '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_create_edge(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 1, 'testName', {'testKey': 'testValue'})
+        edge = git.graph.edges[edgeId]
+        self.assertIsNotNone(edge.sourceKey, "edge attribute 'sourceKey' is None")
+        self.assertEqual(edge.sourceKey, 'testSourceKey', "edge attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(edge.sourceKey))
+        self.assertIsNotNone(edge.fromNodeId, "edge attribute 'fromNodeId' is None")
+        self.assertEqual(edge.fromNodeId, 0, "edge attribute 'fromNodeId', Expected: 0, "
+                                             "Actual: " + str(edge.fromNodeId))
+        self.assertIsNotNone(edge.toNodeId, "edge attribute 'toNodeId' is None")
+        self.assertEqual(edge.toNodeId, 1, "edge attribute 'toNodeId', Expected: 1, "
+                                           "Actual: " + str(edge.toNodeId))
+        self.assertIsNotNone(edge.name, "edge attribute 'name' is None")
+        self.assertEqual(edge.name, 'testName', "edge attribute 'name', Expected: testName, "
+                                                "Actual: " + str(edge.name))
+        self.assertIsNotNone(edge.tags, "edge attribute 'tags' is None")
+        self.assertEqual(edge.tags, {'testKey': 'testValue'},
+                         "edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(edge.tags))
+        edge_json = edge.to_json()
+        self.assertEqual(edge_json, '{"fromNodeId": 0, "name": "testName", "edgeId": 0, '
+                                    '"tags": {"testKey": "testValue"}, "class": "Edge", '
+                                    '"toNodeId": 1, "sourceKey": "testSourceKey"}')
+
+    def test_git_create_graph(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        graph = git.graph.graphs[graphId]
+        self.assertIsNotNone(graph.sourceKey, "graph attribute 'sourceKey' is None")
+        self.assertEqual(graph.sourceKey, 'testSourceKey', "graph attribute 'sourceKey', "
+                                                           "Expected: testSourceKey, Actual: " + str(graph.sourceKey))
+        self.assertIsNotNone(graph.name, "graph attribute 'name' is None")
+        self.assertEqual(graph.name, 'testName', "graph attribute 'name', Expected: testName, "
+                                                 "Actual: " + str(graph.name))
+        self.assertIsNotNone(graph.tags, "graph attribute 'tags' is None")
+        self.assertEqual(graph.tags, {'testKey': 'testValue'},
+                         "graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(graph.tags))
+        self.assertEqual(graph.nodes, {})
+        self.assertEqual(graph.nodeVersions, {})
+        self.assertEqual(graph.edges, {})
+        self.assertEqual(graph.edgeVersions, {})
+        self.assertEqual(graph.graphs, {})
+        self.assertEqual(graph.graphVersions, {})
+        self.assertEqual(graph.structures, {})
+        self.assertEqual(graph.structureVersions, {})
+        self.assertEqual(graph.lineageEdges, {})
+        self.assertEqual(graph.lineageEdgeVersions, {})
+        self.assertEqual(graph.lineageGraphs, {})
+        self.assertEqual(graph.lineageGraphVersions, {})
+        self.assertEqual(graph.ids, set([]))
+        for i in range(100):
+            testId = graph.gen_id()
+            self.assertIn(testId, graph.ids)
+            self.assertNotIn(len(graph.ids), graph.ids)
+        graph_json = graph.to_json()
+        self.assertEqual(graph_json, '{"class": "Graph", "graphId": 0, "sourceKey": "testSourceKey", '
+                                     '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_create_structure(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        structure = git.graph.structures[structureId]
+        self.assertIsNotNone(structure.sourceKey, "structure attribute 'sourceKey' is None")
+        self.assertEqual(structure.sourceKey, 'testSourceKey', "structure attribute 'sourceKey', "
+                                                               "Expected: testSourceKey, "
+                                                               "Actual: " + str(structure.sourceKey))
+        self.assertIsNotNone(structure.name, "structure attribute 'name' is None")
+        self.assertEqual(structure.name, 'testName', "structure attribute 'name', Expected: testName, "
+                                                     "Actual: " + str(structure.name))
+        self.assertIsNotNone(structure.tags, "structure attribute 'tags' is None")
+        self.assertEqual(structure.tags, {'testKey': 'testValue'},
+                         "structure attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(structure.tags))
+        structure_json = structure.to_json()
+        self.assertEqual(structure_json, '{"class": "Structure", "structureId": 0, "sourceKey": "testSourceKey", '
+                                         '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_create_lineage_edge(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_edge = git.graph.lineageEdges[lineageEdgeId]
+        self.assertIsNotNone(lineage_edge.sourceKey, "lineage_edge attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge.sourceKey, 'testSourceKey', "lineage_edge attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(lineage_edge.sourceKey))
+        self.assertIsNotNone(lineage_edge.name, "lineage_edge attribute 'name' is None")
+        self.assertEqual(lineage_edge.name, 'testName', "lineage_edge attribute 'name', Expected: testName, "
+                                                        "Actual: " + str(lineage_edge.name))
+        self.assertIsNotNone(lineage_edge.tags, "lineage_edge attribute 'tags' is None")
+        self.assertEqual(lineage_edge.tags, {'testKey': 'testValue'},
+                         "lineage_edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge.tags))
+        lineage_edge_json = lineage_edge.to_json()
+        self.assertEqual(lineage_edge_json, '{"class": "LineageEdge", "tags": {"testKey": "testValue"}, '
+                                            '"sourceKey": "testSourceKey", "lineageEdgeId": 0, "name": "testName"}')
+
+    def test_git_create_lineage_graph(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_graph = git.graph.lineageGraphs[lineageGraphId]
+        self.assertIsNotNone(lineage_graph.sourceKey, "lineage_graph attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph.sourceKey, 'testSourceKey', "lineage_graph attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(lineage_graph.sourceKey))
+        self.assertIsNotNone(lineage_graph.name, "lineage_graph attribute 'name' is None")
+        self.assertEqual(lineage_graph.name, 'testName', "lineage_graph attribute 'name', Expected: testName, "
+                                                         "Actual: " + str(lineage_graph.name))
+        self.assertIsNotNone(lineage_graph.tags, "lineage_graph attribute 'tags' is None")
+        self.assertEqual(lineage_graph.tags, {'testKey': 'testValue'},
+                         "lineage_graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph.tags))
+        lineage_graph_json = lineage_graph.to_json()
+        self.assertEqual(lineage_graph_json, '{"lineageGraphId": 0, "class": "LineageGraph", '
+                                             '"tags": {"testKey": "testValue"}, '
+                                             '"sourceKey": "testSourceKey", "name": "testName"}')
+
+    def test_git_get_node(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey', 'testName', {'testKey': 'testValue'})
+        node = git.getNode('testSourceKey')
+        self.assertIsNotNone(node.sourceKey, "node attribute 'sourceKey' is None")
+        self.assertEqual(node.sourceKey, 'testSourceKey', "node attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(node.sourceKey))
+        self.assertIsNotNone(node.name, "node attribute 'name' is None")
+        self.assertEqual(node.name, 'testName', "node attribute 'name', Expected: testName, "
+                                                "Actual: " + str(node.name))
+        self.assertIsNotNone(node.tags, "node attribute 'tags' is None")
+        self.assertEqual(node.tags, {'testKey': 'testValue'},
+                         "node attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(node.tags))
+        node_json = node.to_json()
+        self.assertEqual(node_json, '{"nodeId": 0, "class": "Node", "sourceKey": "testSourceKey", '
+                                    '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_get_edge(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 1, 'testName', {'testKey': 'testValue'})
+        edge = git.getEdge('testSourceKey')
+        self.assertIsNotNone(edge.sourceKey, "edge attribute 'sourceKey' is None")
+        self.assertEqual(edge.sourceKey, 'testSourceKey', "edge attribute 'sourceKey', "
+                                                          "Expected: testSourceKey, Actual: " + str(edge.sourceKey))
+        self.assertIsNotNone(edge.fromNodeId, "edge attribute 'fromNodeId' is None")
+        self.assertEqual(edge.fromNodeId, 0, "edge attribute 'fromNodeId', Expected: 0, "
+                                             "Actual: " + str(edge.fromNodeId))
+        self.assertIsNotNone(edge.toNodeId, "edge attribute 'toNodeId' is None")
+        self.assertEqual(edge.toNodeId, 1, "edge attribute 'toNodeId', Expected: 1, "
+                                           "Actual: " + str(edge.toNodeId))
+        self.assertIsNotNone(edge.name, "edge attribute 'name' is None")
+        self.assertEqual(edge.name, 'testName', "edge attribute 'name', Expected: testName, "
+                                                "Actual: " + str(edge.name))
+        self.assertIsNotNone(edge.tags, "edge attribute 'tags' is None")
+        self.assertEqual(edge.tags, {'testKey': 'testValue'},
+                         "edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(edge.tags))
+        edge_json = edge.to_json()
+        self.assertEqual(edge_json, '{"fromNodeId": 0, "name": "testName", "edgeId": 0, '
+                                    '"tags": {"testKey": "testValue"}, "class": "Edge", '
+                                    '"toNodeId": 1, "sourceKey": "testSourceKey"}')
+
+    def test_git_get_graph(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        graph = git.getGraph('testSourceKey')
+        self.assertIsNotNone(graph.sourceKey, "graph attribute 'sourceKey' is None")
+        self.assertEqual(graph.sourceKey, 'testSourceKey', "graph attribute 'sourceKey', "
+                                                           "Expected: testSourceKey, Actual: " + str(graph.sourceKey))
+        self.assertIsNotNone(graph.name, "graph attribute 'name' is None")
+        self.assertEqual(graph.name, 'testName', "graph attribute 'name', Expected: testName, "
+                                                 "Actual: " + str(graph.name))
+        self.assertIsNotNone(graph.tags, "graph attribute 'tags' is None")
+        self.assertEqual(graph.tags, {'testKey': 'testValue'},
+                         "graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(graph.tags))
+        self.assertEqual(graph.nodes, {})
+        self.assertEqual(graph.nodeVersions, {})
+        self.assertEqual(graph.edges, {})
+        self.assertEqual(graph.edgeVersions, {})
+        self.assertEqual(graph.graphs, {})
+        self.assertEqual(graph.graphVersions, {})
+        self.assertEqual(graph.structures, {})
+        self.assertEqual(graph.structureVersions, {})
+        self.assertEqual(graph.lineageEdges, {})
+        self.assertEqual(graph.lineageEdgeVersions, {})
+        self.assertEqual(graph.lineageGraphs, {})
+        self.assertEqual(graph.lineageGraphVersions, {})
+        self.assertEqual(graph.ids, set([]))
+        for i in range(100):
+            testId = graph.gen_id()
+            self.assertIn(testId, graph.ids)
+            self.assertNotIn(len(graph.ids), graph.ids)
+        graph_json = graph.to_json()
+        self.assertEqual(graph_json, '{"class": "Graph", "graphId": 0, "sourceKey": "testSourceKey", '
+                                     '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_get_structure(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        structure = git.getStructure('testSourceKey')
+        self.assertIsNotNone(structure.sourceKey, "structure attribute 'sourceKey' is None")
+        self.assertEqual(structure.sourceKey, 'testSourceKey', "structure attribute 'sourceKey', "
+                                                               "Expected: testSourceKey, "
+                                                               "Actual: " + str(structure.sourceKey))
+        self.assertIsNotNone(structure.name, "structure attribute 'name' is None")
+        self.assertEqual(structure.name, 'testName', "structure attribute 'name', Expected: testName, "
+                                                     "Actual: " + str(structure.name))
+        self.assertIsNotNone(structure.tags, "structure attribute 'tags' is None")
+        self.assertEqual(structure.tags, {'testKey': 'testValue'},
+                         "structure attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(structure.tags))
+        structure_json = structure.to_json()
+        self.assertEqual(structure_json, '{"class": "Structure", "structureId": 0, "sourceKey": "testSourceKey", '
+                                         '"name": "testName", "tags": {"testKey": "testValue"}}')
+
+    def test_git_get_lineage_edge(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_edge = git.getLineageEdge('testSourceKey')
+        self.assertIsNotNone(lineage_edge.sourceKey, "lineage_edge attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge.sourceKey, 'testSourceKey', "lineage_edge attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(lineage_edge.sourceKey))
+        self.assertIsNotNone(lineage_edge.name, "lineage_edge attribute 'name' is None")
+        self.assertEqual(lineage_edge.name, 'testName', "lineage_edge attribute 'name', Expected: testName, "
+                                                        "Actual: " + str(lineage_edge.name))
+        self.assertIsNotNone(lineage_edge.tags, "lineage_edge attribute 'tags' is None")
+        self.assertEqual(lineage_edge.tags, {'testKey': 'testValue'},
+                         "lineage_edge attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge.tags))
+        lineage_edge_json = lineage_edge.to_json()
+        self.assertEqual(lineage_edge_json, '{"class": "LineageEdge", "tags": {"testKey": "testValue"}, '
+                                            '"sourceKey": "testSourceKey", "lineageEdgeId": 0, "name": "testName"}')
+
+    def test_git_get_lineage_graph(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineage_graph = git.getLineageGraph('testSourceKey')
+        self.assertIsNotNone(lineage_graph.sourceKey, "lineage_graph attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph.sourceKey, 'testSourceKey', "lineage_graph attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(lineage_graph.sourceKey))
+        self.assertIsNotNone(lineage_graph.name, "lineage_graph attribute 'name' is None")
+        self.assertEqual(lineage_graph.name, 'testName', "lineage_graph attribute 'name', Expected: testName, "
+                                                         "Actual: " + str(lineage_graph.name))
+        self.assertIsNotNone(lineage_graph.tags, "lineage_graph attribute 'tags' is None")
+        self.assertEqual(lineage_graph.tags, {'testKey': 'testValue'},
+                         "lineage_graph attribute 'sourceKey', Expected: "
+                         "" + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph.tags))
+        lineage_graph_json = lineage_graph.to_json()
+        self.assertEqual(lineage_graph_json, '{"lineageGraphId": 0, "class": "LineageGraph", '
+                                             '"tags": {"testKey": "testValue"}, '
+                                             '"sourceKey": "testSourceKey", "name": "testName"}')
+
+    def test_git_create_node_version(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey', 'testName', {'testKey': 'testValue'})
+        nodeVersionId = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                              {'testKey': 'testValue'}, 1, [2, 3])
+        node_version = git.graph.nodeVersions[nodeVersionId]
+        self.assertIsNotNone(node_version.sourceKey, "node_version attribute 'sourceKey' is None")
+        self.assertEqual(node_version.sourceKey, 'testSourceKey', "node_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(node_version.sourceKey))
+        self.assertIsNotNone(node_version.nodeId, "node_version attribute 'nodeId' is None")
+        self.assertEqual(node_version.nodeId, 0, "node_version attribute 'nodeId', "
+                                                 "Expected: 0, Actual: " + str(node_version.nodeId))
+        self.assertIsNotNone(node_version.reference, "node_version attribute 'reference' is None")
+        self.assertEqual(node_version.reference, "testReference", "node_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(node_version.reference))
+        self.assertIsNotNone(node_version.referenceParameters, "node_version attribute 'referenceParameters' is None")
+        self.assertEqual(node_version.referenceParameters, "testReferenceParameters", "node_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            node_version.referenceParameters))
+        self.assertIsNotNone(node_version.tags, "node_version attribute 'tags' is None")
+        self.assertEqual(node_version.tags,
+                         {'testKey': 'testValue'},
+                         "node_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(node_version.tags))
+        self.assertIsNotNone(node_version.structureVersionId, "node_version attribute 'structureVersionId' is None")
+        self.assertEqual(node_version.structureVersionId, 1, "node_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(node_version.structureVersionId))
+        self.assertIsNotNone(node_version.parentIds, "node_version attribute 'parentIds' is None")
+        self.assertEqual(node_version.parentIds, [2, 3], "node_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(node_version.parentIds))
+        node_version_json = node_version.to_json()
+        self.assertEqual(node_version_json, '{"nodeVersionId": 1, "reference": "testReference", '
+                                            '"tags": {"testKey": "testValue"}, '
+                                            '"referenceParameters": "testReferenceParameters", "class": "NodeVersion", '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"sourceKey": "testSourceKey", "nodeId": 0}')
+
+    def test_git_create_edge_version(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 10, 'testName', {'testKey': 'testValue'})
+        edgeVersionId = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                              {'testKey': 'testValue'}, 1, [2, 3])
+        edge_version = git.graph.edgeVersions[edgeVersionId]
+        self.assertIsNotNone(edge_version.sourceKey, "edge_version attribute 'sourceKey' is None")
+        self.assertEqual(edge_version.sourceKey, 'testSourceKey', "edge_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(edge_version.sourceKey))
+        self.assertIsNotNone(edge_version.fromNodeId, "edge_version attribute 'fromNodeId' is None")
+        self.assertEqual(edge_version.fromNodeId, 0, "edge_version attribute 'fromNodeId', "
+                                                     "Expected: 0, Actual: " + str(edge_version.fromNodeId))
+        self.assertIsNotNone(edge_version.toNodeId, "edge_version attribute 'toNodeId' is None")
+        self.assertEqual(edge_version.toNodeId, 10, "edge_version attribute 'toNodeId', "
+                                                    "Expected: 10, Actual: " + str(edge_version.toNodeId))
+        self.assertIsNotNone(edge_version.edgeId, "edge_version attribute 'edgeId' is None")
+        self.assertEqual(edge_version.edgeId, 0, "edge_version attribute 'edgeId', "
+                                                 "Expected: 0, Actual: " + str(edge_version.edgeId))
+        self.assertIsNotNone(edge_version.toNodeVersionStartId, "edge_version attribute 'toNodeVersionStartId' is None")
+        self.assertEqual(edge_version.toNodeVersionStartId, 4, "edge_version attribute 'toNodeVersionStartId', "
+                                                               "Expected: 4, Actual: " + str(
+            edge_version.toNodeVersionStartId))
+        self.assertIsNotNone(edge_version.fromNodeVersionStartId, "edge_version attribute 'fromNodeVersionStartId' "
+                                                                  "is None")
+        self.assertEqual(edge_version.fromNodeVersionStartId, 5, "edge_version attribute 'fromNodeVersionStartId', "
+                                                                 "Expected: 5, Actual: " + str(
+            edge_version.fromNodeVersionStartId))
+        self.assertIsNotNone(edge_version.toNodeVersionEndId, "edge_version attribute 'toNodeVersionEndId' is None")
+        self.assertEqual(edge_version.toNodeVersionEndId, 6, "edge_version attribute 'toNodeVersionEndId', "
+                                                             "Expected: 6, Actual: " + str(
+            edge_version.toNodeVersionEndId))
+        self.assertIsNotNone(edge_version.fromNodeVersionEndId, "edge_version attribute 'fromNodeVersionEndId' is None")
+        self.assertEqual(edge_version.fromNodeVersionEndId, 7, "edge_version attribute 'fromNodeVersionEndId', "
+                                                               "Expected: 7, Actual: " + str(
+            edge_version.fromNodeVersionEndId))
+        self.assertIsNotNone(edge_version.reference, "edge_version attribute 'reference' is None")
+        self.assertEqual(edge_version.reference, "testReference", "edge_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(edge_version.reference))
+        self.assertIsNotNone(edge_version.referenceParameters, "edge_version attribute 'referenceParameters' is None")
+        self.assertEqual(edge_version.referenceParameters, "testReferenceParameters", "edge_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            edge_version.referenceParameters))
+        self.assertIsNotNone(edge_version.tags, "edge_version attribute 'tags' is None")
+        self.assertEqual(edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(edge_version.tags))
+        self.assertIsNotNone(edge_version.structureVersionId, "edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(edge_version.structureVersionId, 1, "edge_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(edge_version.structureVersionId))
+        self.assertIsNotNone(edge_version.parentIds, "edge_version attribute 'parentIds' is None")
+        self.assertEqual(edge_version.parentIds, [2, 3], "edge_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(edge_version.parentIds))
+        edge_version_json = edge_version.to_json()
+        self.assertEqual(edge_version_json, '{"toNodeVersionStartId": 4, "toNodeVersionEndId": 6, '
+                                            '"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                            '"edgeVersionId": 1, "referenceParameters": "testReferenceParameters", '
+                                            '"class": "EdgeVersion", "fromNodeId": 0, "edgeId": 0, '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"fromNodeVersionStartId": 5, "toNodeId": 10, '
+                                            '"fromNodeVersionEndId": 7, "sourceKey": "testSourceKey"}')
+
+    def test_git_create_graph_version(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        graphVersionId = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                {'testKey': 'testValue'}, 1, [2, 3])
+        graph_version = git.graph.graphVersions[graphVersionId]
+        self.assertIsNotNone(graph_version.sourceKey, "graph_version attribute 'sourceKey' is None")
+        self.assertEqual(graph_version.sourceKey, 'testSourceKey', "graph_version attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(graph_version.sourceKey))
+        self.assertIsNotNone(graph_version.graphId, "graph_version attribute 'graphId' is None")
+        self.assertEqual(graph_version.graphId, 0, "graph_version attribute 'graphId', "
+                                                   "Expected: 0, Actual: " + str(graph_version.graphId))
+        self.assertIsNotNone(graph_version.edgeVersionIds, "graph_version attribute 'edgeVersionIds' is None")
+        self.assertEqual(graph_version.edgeVersionIds, [4, 5, 6], "graph_version attribute 'edgeVersionIds', "
+                                                                  "Expected: [4, 5, 6], "
+                                                                  "Actual: " + str(graph_version.edgeVersionIds))
+        self.assertIsNotNone(graph_version.reference, "graph_version attribute 'reference' is None")
+        self.assertEqual(graph_version.reference, "testReference", "graph_version attribute 'reference', "
+                                                                   "Expected: testReference, "
+                                                                   "Actual: " + str(graph_version.reference))
+        self.assertIsNotNone(graph_version.referenceParameters, "graph_version attribute 'referenceParameters' is None")
+        self.assertEqual(graph_version.referenceParameters, "testReferenceParameters", "graph_version attribute "
+                                                                                       "'referenceParameters', "
+                                                                                       "Expected: testReferenceParameters, "
+                                                                                       "Actual: " + str(
+            graph_version.referenceParameters))
+        self.assertIsNotNone(graph_version.tags, "graph_version attribute 'tags' is None")
+        self.assertEqual(graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(graph_version.tags))
+        self.assertIsNotNone(graph_version.structureVersionId, "graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(graph_version.structureVersionId, 1, "graph_version attribute 'structureVersionId', "
+                                                              "Expected: 1, "
+                                                              "Actual: " + str(graph_version.structureVersionId))
+        self.assertIsNotNone(graph_version.parentIds, "graph_version attribute 'parentIds' is None")
+        self.assertEqual(graph_version.parentIds, [2, 3], "graph_version attribute 'parentIds', "
+                                                          "Expected: [2, 3], "
+                                                          "Actual: " + str(graph_version.parentIds))
+        graph_version_json = graph_version.to_json()
+        self.assertEqual(graph_version_json, '{"parentIds": [2, 3], "graphId": 0, "reference": "testReference", '
+                                             '"edgeVersionIds": [4, 5, 6], '
+                                             '"referenceParameters": "testReferenceParameters", '
+                                             '"graphVersionId": 1, "tags": {"testKey": "testValue"}, '
+                                             '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                             '"class": "GraphVersion"}')
+
+    def test_git_create_structure_version(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        structureVersionId = git.createStructureVersion(structureId, {'testKey': 'testValue'}, [2, 3])
+        structure_version = git.graph.structureVersions[structureVersionId]
+        self.assertIsNotNone(structure_version.sourceKey, "structure_version attribute 'sourceKey' is None")
+        self.assertEqual(structure_version.sourceKey, 'testSourceKey', "structure_version attribute 'sourceKey', "
+                                                                       "Expected: testSourceKey, "
+                                                                       "Actual: " + str(structure_version.sourceKey))
+        self.assertIsNotNone(structure_version.structureId, "structure_version attribute 'structureId' is None")
+        self.assertEqual(structure_version.structureId, 0, "structure_version attribute 'structureId', "
+                                                           "Expected: 0, Actual: " + str(structure_version.structureId))
+        self.assertIsNotNone(structure_version.attributes, "structure_version attribute 'attributes' is None")
+        self.assertEqual(structure_version.attributes, {'testKey': 'testValue'}, "structure_version "
+                                                                                 "attribute 'attributes', "
+                                                                                 "Expected: , " + str(
+            {'testKey': 'testValue'}) +
+                         ", Actual: " + str(structure_version.attributes))
+        self.assertIsNotNone(structure_version.parentIds, "structure_version attribute 'parentIds' is None")
+        self.assertEqual(structure_version.parentIds, [2, 3], "structure_version attribute 'parentIds', "
+                                                              "Expected: [2, 3], "
+                                                              "Actual: " + str(structure_version.parentIds))
+        structure_version_json = structure_version.to_json()
+        self.assertEqual(structure_version_json, '{"parentIds": [2, 3], "structureId": 0, "structureVersionId": 1, '
+                                                 '"sourceKey": "testSourceKey", '
+                                                 '"attributes": {"testKey": "testValue"}, '
+                                                 '"class": "StructureVersion"}')
+
+    def test_git_create_lineage_edge_version(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineageEdgeVersionId = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                            "testReferenceParameters",
+                                                            {'testKey': 'testValue'}, 1, [2, 3])
+        lineage_edge_version = git.graph.lineageEdgeVersions[lineageEdgeVersionId]
+        self.assertIsNotNone(lineage_edge_version.sourceKey, "lineage_edge_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge_version.sourceKey, 'testSourceKey', "lineage_edge_version attribute 'sourceKey', "
+                                                                          "Expected: testSourceKey, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.sourceKey))
+        self.assertIsNotNone(lineage_edge_version.lineageEdgeId, "lineage_edge_version attribute "
+                                                                 "'lineageEdgeId' is None")
+        self.assertEqual(lineage_edge_version.lineageEdgeId, 0, "lineage_edge_version attribute 'lineageEdgeId', "
+                                                                "Expected: 0, Actual: " + str(
+            lineage_edge_version.lineageEdgeId))
+        self.assertIsNotNone(lineage_edge_version.fromRichVersionId, "lineage_edge_version attribute "
+                                                                     "'fromRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.fromRichVersionId, 4,
+                         "lineage_edge_version attribute 'fromRichVersionId', "
+                         "Expected: 4, Actual: " + str(lineage_edge_version.fromRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.toRichVersionId, "lineage_edge_version attribute "
+                                                                   "'toRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.toRichVersionId, 5, "lineage_edge_version attribute 'toRichVersionId', "
+                                                                  "Expected: 5, Actual: " + str(
+            lineage_edge_version.toRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.reference, "lineage_edge_version attribute 'reference' is None")
+        self.assertEqual(lineage_edge_version.reference, "testReference", "lineage_edge_version attribute 'reference', "
+                                                                          "Expected: testReference, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.reference))
+        self.assertIsNotNone(lineage_edge_version.referenceParameters, "lineage_edge_version attribute "
+                                                                       "'referenceParameters' is None")
+        self.assertEqual(lineage_edge_version.referenceParameters, "testReferenceParameters",
+                         "lineage_edge_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_edge_version.referenceParameters))
+        self.assertIsNotNone(lineage_edge_version.tags, "lineage_edge_version attribute 'tags' is None")
+        self.assertEqual(lineage_edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge_version.tags))
+        self.assertIsNotNone(lineage_edge_version.structureVersionId,
+                             "lineage_edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_edge_version.structureVersionId, 1,
+                         "lineage_edge_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_edge_version.structureVersionId))
+        self.assertIsNotNone(lineage_edge_version.parentIds, "lineage_edge_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_edge_version.parentIds, [2, 3], "lineage_edge_version attribute 'parentIds', "
+                                                                 "Expected: [2, 3], "
+                                                                 "Actual: " + str(lineage_edge_version.parentIds))
+        lineage_edge_version_json = lineage_edge_version.to_json()
+        self.assertEqual(lineage_edge_version_json, '{"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                                    '"lineageEdgeVersionId": 1, '
+                                                    '"referenceParameters": "testReferenceParameters", '
+                                                    '"fromRichVersionId": 4, "class": "LineageEdgeVersion", '
+                                                    '"parentIds": [2, 3], "structureVersionId": 1, '
+                                                    '"toRichVersionId": 5, "lineageEdgeId": 0, '
+                                                    '"sourceKey": "testSourceKey"}')
+
+    def test_git_create_lineage_graph_version(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineageGraphVersionId = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                              "testReferenceParameters",
+                                                              {'testKey': 'testValue'}, 1, [2, 3])
+        lineage_graph_version = git.graph.lineageGraphVersions[lineageGraphVersionId]
+        self.assertIsNotNone(lineage_graph_version.sourceKey, "lineage_graph_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph_version.sourceKey, 'testSourceKey',
+                         "lineage_graph_version attribute 'sourceKey', "
+                         "Expected: testSourceKey, "
+                         "Actual: " + str(
+                             lineage_graph_version.sourceKey))
+        self.assertIsNotNone(lineage_graph_version.lineageGraphId, "lineage_graph_version attribute "
+                                                                   "'lineageGraphId' is None")
+        self.assertEqual(lineage_graph_version.lineageGraphId, 0, "lineage_graph_version attribute 'lineageGraphId', "
+                                                                  "Expected: 0, Actual: " + str(
+            lineage_graph_version.lineageGraphId))
+        self.assertIsNotNone(lineage_graph_version.lineageEdgeVersionIds, "lineage_graph_version attribute "
+                                                                          "'lineageEdgeVersionIds' is None")
+        self.assertEqual(lineage_graph_version.lineageEdgeVersionIds, [5, 4],
+                         "lineage_graph_version attribute 'lineageEdgeVersionIds', "
+                         "Expected: [5, 4], Actual: " + str(lineage_graph_version.lineageEdgeVersionIds))
+        self.assertIsNotNone(lineage_graph_version.reference, "lineage_graph_version attribute 'reference' is None")
+        self.assertEqual(lineage_graph_version.reference, "testReference",
+                         "lineage_graph_version attribute 'reference', "
+                         "Expected: testReference, "
+                         "Actual: " + str(
+                             lineage_graph_version.reference))
+        self.assertIsNotNone(lineage_graph_version.referenceParameters, "lineage_graph_version attribute "
+                                                                        "'referenceParameters' is None")
+        self.assertEqual(lineage_graph_version.referenceParameters, "testReferenceParameters",
+                         "lineage_graph_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_graph_version.referenceParameters))
+        self.assertIsNotNone(lineage_graph_version.tags, "lineage_graph_version attribute 'tags' is None")
+        self.assertEqual(lineage_graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph_version.tags))
+        self.assertIsNotNone(lineage_graph_version.structureVersionId,
+                             "lineage_graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_graph_version.structureVersionId, 1,
+                         "lineage_graph_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_graph_version.structureVersionId))
+        self.assertIsNotNone(lineage_graph_version.parentIds, "lineage_graph_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_graph_version.parentIds, [2, 3], "lineage_graph_version attribute 'parentIds', "
+                                                                  "Expected: [2, 3], "
+                                                                  "Actual: " + str(lineage_graph_version.parentIds))
+        lineage_graph_version_json = lineage_graph_version.to_json()
+        self.assertEqual(lineage_graph_version_json, '{"lineageGraphId": 0, "lineageGraphVersionId": 1, '
+                                                     '"parentIds": [2, 3], "reference": "testReference", '
+                                                     '"tags": {"testKey": "testValue"}, '
+                                                     '"referenceParameters": "testReferenceParameters", '
+                                                     '"lineageEdgeVersionIds": [5, 4], '
+                                                     '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                                     '"class": "LineageGraphVersion"}')
+
+    def test_git_get_node_version(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey', 'testName', {'testKey': 'testValue'})
+        nodeVersionId = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                              {'testKey': 'testValue'}, 1, [2, 3])
+        node_version = git.getNodeVersion(nodeVersionId)
+        self.assertIsNotNone(node_version.sourceKey, "node_version attribute 'sourceKey' is None")
+        self.assertEqual(node_version.sourceKey, 'testSourceKey', "node_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(node_version.sourceKey))
+        self.assertIsNotNone(node_version.nodeId, "node_version attribute 'nodeId' is None")
+        self.assertEqual(node_version.nodeId, 0, "node_version attribute 'nodeId', "
+                                                 "Expected: 0, Actual: " + str(node_version.nodeId))
+        self.assertIsNotNone(node_version.reference, "node_version attribute 'reference' is None")
+        self.assertEqual(node_version.reference, "testReference", "node_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(node_version.reference))
+        self.assertIsNotNone(node_version.referenceParameters, "node_version attribute 'referenceParameters' is None")
+        self.assertEqual(node_version.referenceParameters, "testReferenceParameters", "node_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            node_version.referenceParameters))
+        self.assertIsNotNone(node_version.tags, "node_version attribute 'tags' is None")
+        self.assertEqual(node_version.tags,
+                         {'testKey': 'testValue'},
+                         "node_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(node_version.tags))
+        self.assertIsNotNone(node_version.structureVersionId, "node_version attribute 'structureVersionId' is None")
+        self.assertEqual(node_version.structureVersionId, 1, "node_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(node_version.structureVersionId))
+        self.assertIsNotNone(node_version.parentIds, "node_version attribute 'parentIds' is None")
+        self.assertEqual(node_version.parentIds, [2, 3], "node_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(node_version.parentIds))
+        node_version_json = node_version.to_json()
+        self.assertEqual(node_version_json, '{"nodeVersionId": 1, "reference": "testReference", '
+                                            '"tags": {"testKey": "testValue"}, '
+                                            '"referenceParameters": "testReferenceParameters", "class": "NodeVersion", '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"sourceKey": "testSourceKey", "nodeId": 0}')
+
+    def test_git_get_edge_version(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 10, 'testName', {'testKey': 'testValue'})
+        edgeVersionId = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                              {'testKey': 'testValue'}, 1, [2, 3])
+        edge_version = git.getEdgeVersion(edgeVersionId)
+        self.assertIsNotNone(edge_version.sourceKey, "edge_version attribute 'sourceKey' is None")
+        self.assertEqual(edge_version.sourceKey, 'testSourceKey', "edge_version attribute 'sourceKey', "
+                                                                  "Expected: testSourceKey, "
+                                                                  "Actual: " + str(edge_version.sourceKey))
+        self.assertIsNotNone(edge_version.fromNodeId, "edge_version attribute 'fromNodeId' is None")
+        self.assertEqual(edge_version.fromNodeId, 0, "edge_version attribute 'fromNodeId', "
+                                                     "Expected: 0, Actual: " + str(edge_version.fromNodeId))
+        self.assertIsNotNone(edge_version.toNodeId, "edge_version attribute 'toNodeId' is None")
+        self.assertEqual(edge_version.toNodeId, 10, "edge_version attribute 'toNodeId', "
+                                                    "Expected: 10, Actual: " + str(edge_version.toNodeId))
+        self.assertIsNotNone(edge_version.edgeId, "edge_version attribute 'edgeId' is None")
+        self.assertEqual(edge_version.edgeId, 0, "edge_version attribute 'edgeId', "
+                                                 "Expected: 0, Actual: " + str(edge_version.edgeId))
+        self.assertIsNotNone(edge_version.toNodeVersionStartId, "edge_version attribute 'toNodeVersionStartId' is None")
+        self.assertEqual(edge_version.toNodeVersionStartId, 4, "edge_version attribute 'toNodeVersionStartId', "
+                                                               "Expected: 4, Actual: " + str(
+            edge_version.toNodeVersionStartId))
+        self.assertIsNotNone(edge_version.fromNodeVersionStartId, "edge_version attribute 'fromNodeVersionStartId' "
+                                                                  "is None")
+        self.assertEqual(edge_version.fromNodeVersionStartId, 5, "edge_version attribute 'fromNodeVersionStartId', "
+                                                                 "Expected: 5, Actual: " + str(
+            edge_version.fromNodeVersionStartId))
+        self.assertIsNotNone(edge_version.toNodeVersionEndId, "edge_version attribute 'toNodeVersionEndId' is None")
+        self.assertEqual(edge_version.toNodeVersionEndId, 6, "edge_version attribute 'toNodeVersionEndId', "
+                                                             "Expected: 6, Actual: " + str(
+            edge_version.toNodeVersionEndId))
+        self.assertIsNotNone(edge_version.fromNodeVersionEndId, "edge_version attribute 'fromNodeVersionEndId' is None")
+        self.assertEqual(edge_version.fromNodeVersionEndId, 7, "edge_version attribute 'fromNodeVersionEndId', "
+                                                               "Expected: 7, Actual: " + str(
+            edge_version.fromNodeVersionEndId))
+        self.assertIsNotNone(edge_version.reference, "edge_version attribute 'reference' is None")
+        self.assertEqual(edge_version.reference, "testReference", "edge_version attribute 'reference', "
+                                                                  "Expected: testReference, "
+                                                                  "Actual: " + str(edge_version.reference))
+        self.assertIsNotNone(edge_version.referenceParameters, "edge_version attribute 'referenceParameters' is None")
+        self.assertEqual(edge_version.referenceParameters, "testReferenceParameters", "edge_version attribute "
+                                                                                      "'referenceParameters', "
+                                                                                      "Expected: testReferenceParameters, "
+                                                                                      "Actual: " + str(
+            edge_version.referenceParameters))
+        self.assertIsNotNone(edge_version.tags, "edge_version attribute 'tags' is None")
+        self.assertEqual(edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(edge_version.tags))
+        self.assertIsNotNone(edge_version.structureVersionId, "edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(edge_version.structureVersionId, 1, "edge_version attribute 'structureVersionId', "
+                                                             "Expected: 1, "
+                                                             "Actual: " + str(edge_version.structureVersionId))
+        self.assertIsNotNone(edge_version.parentIds, "edge_version attribute 'parentIds' is None")
+        self.assertEqual(edge_version.parentIds, [2, 3], "edge_version attribute 'parentIds', "
+                                                         "Expected: [2, 3], "
+                                                         "Actual: " + str(edge_version.parentIds))
+        edge_version_json = edge_version.to_json()
+        self.assertEqual(edge_version_json, '{"toNodeVersionStartId": 4, "toNodeVersionEndId": 6, '
+                                            '"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                            '"edgeVersionId": 1, "referenceParameters": "testReferenceParameters", '
+                                            '"class": "EdgeVersion", "fromNodeId": 0, "edgeId": 0, '
+                                            '"parentIds": [2, 3], "structureVersionId": 1, '
+                                            '"fromNodeVersionStartId": 5, "toNodeId": 10, '
+                                            '"fromNodeVersionEndId": 7, "sourceKey": "testSourceKey"}')
+
+    def test_git_get_graph_version(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        graphVersionId = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                {'testKey': 'testValue'}, 1, [2, 3])
+        graph_version = git.getGraphVersion(graphVersionId)
+        self.assertIsNotNone(graph_version.sourceKey, "graph_version attribute 'sourceKey' is None")
+        self.assertEqual(graph_version.sourceKey, 'testSourceKey', "graph_version attribute 'sourceKey', "
+                                                                   "Expected: testSourceKey, "
+                                                                   "Actual: " + str(graph_version.sourceKey))
+        self.assertIsNotNone(graph_version.graphId, "graph_version attribute 'graphId' is None")
+        self.assertEqual(graph_version.graphId, 0, "graph_version attribute 'graphId', "
+                                                   "Expected: 0, Actual: " + str(graph_version.graphId))
+        self.assertIsNotNone(graph_version.edgeVersionIds, "graph_version attribute 'edgeVersionIds' is None")
+        self.assertEqual(graph_version.edgeVersionIds, [4, 5, 6], "graph_version attribute 'edgeVersionIds', "
+                                                                  "Expected: [4, 5, 6], "
+                                                                  "Actual: " + str(graph_version.edgeVersionIds))
+        self.assertIsNotNone(graph_version.reference, "graph_version attribute 'reference' is None")
+        self.assertEqual(graph_version.reference, "testReference", "graph_version attribute 'reference', "
+                                                                   "Expected: testReference, "
+                                                                   "Actual: " + str(graph_version.reference))
+        self.assertIsNotNone(graph_version.referenceParameters, "graph_version attribute 'referenceParameters' is None")
+        self.assertEqual(graph_version.referenceParameters, "testReferenceParameters", "graph_version attribute "
+                                                                                       "'referenceParameters', "
+                                                                                       "Expected: testReferenceParameters, "
+                                                                                       "Actual: " + str(
+            graph_version.referenceParameters))
+        self.assertIsNotNone(graph_version.tags, "graph_version attribute 'tags' is None")
+        self.assertEqual(graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(graph_version.tags))
+        self.assertIsNotNone(graph_version.structureVersionId, "graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(graph_version.structureVersionId, 1, "graph_version attribute 'structureVersionId', "
+                                                              "Expected: 1, "
+                                                              "Actual: " + str(graph_version.structureVersionId))
+        self.assertIsNotNone(graph_version.parentIds, "graph_version attribute 'parentIds' is None")
+        self.assertEqual(graph_version.parentIds, [2, 3], "graph_version attribute 'parentIds', "
+                                                          "Expected: [2, 3], "
+                                                          "Actual: " + str(graph_version.parentIds))
+        graph_version_json = graph_version.to_json()
+        self.assertEqual(graph_version_json, '{"parentIds": [2, 3], "graphId": 0, "reference": "testReference", '
+                                             '"edgeVersionIds": [4, 5, 6], '
+                                             '"referenceParameters": "testReferenceParameters", '
+                                             '"graphVersionId": 1, "tags": {"testKey": "testValue"}, '
+                                             '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                             '"class": "GraphVersion"}')
+
+    def test_git_get_structure_version(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey', 'testName', {'testKey': 'testValue'})
+        structureVersionId = git.createStructureVersion(structureId, {'testKey': 'testValue'}, [2, 3])
+        structure_version = git.getStructureVersion(structureVersionId)
+        self.assertIsNotNone(structure_version.sourceKey, "structure_version attribute 'sourceKey' is None")
+        self.assertEqual(structure_version.sourceKey, 'testSourceKey', "structure_version attribute 'sourceKey', "
+                                                                       "Expected: testSourceKey, "
+                                                                       "Actual: " + str(structure_version.sourceKey))
+        self.assertIsNotNone(structure_version.structureId, "structure_version attribute 'structureId' is None")
+        self.assertEqual(structure_version.structureId, 0, "structure_version attribute 'structureId', "
+                                                           "Expected: 0, Actual: " + str(structure_version.structureId))
+        self.assertIsNotNone(structure_version.attributes, "structure_version attribute 'attributes' is None")
+        self.assertEqual(structure_version.attributes, {'testKey': 'testValue'}, "structure_version "
+                                                                                 "attribute 'attributes', "
+                                                                                 "Expected: , " + str(
+            {'testKey': 'testValue'}) +
+                         ", Actual: " + str(structure_version.attributes))
+        self.assertIsNotNone(structure_version.parentIds, "structure_version attribute 'parentIds' is None")
+        self.assertEqual(structure_version.parentIds, [2, 3], "structure_version attribute 'parentIds', "
+                                                              "Expected: [2, 3], "
+                                                              "Actual: " + str(structure_version.parentIds))
+        structure_version_json = structure_version.to_json()
+        self.assertEqual(structure_version_json, '{"parentIds": [2, 3], "structureId": 0, "structureVersionId": 1, '
+                                                 '"sourceKey": "testSourceKey", '
+                                                 '"attributes": {"testKey": "testValue"}, '
+                                                 '"class": "StructureVersion"}')
+
+    def test_git_get_lineage_edge_version(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineageEdgeVersionId = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                            "testReferenceParameters",
+                                                            {'testKey': 'testValue'}, 1, [2, 3])
+        lineage_edge_version = git.getLineageEdgeVersion(lineageEdgeVersionId)
+        self.assertIsNotNone(lineage_edge_version.sourceKey, "lineage_edge_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_edge_version.sourceKey, 'testSourceKey', "lineage_edge_version attribute 'sourceKey', "
+                                                                          "Expected: testSourceKey, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.sourceKey))
+        self.assertIsNotNone(lineage_edge_version.lineageEdgeId, "lineage_edge_version attribute "
+                                                                 "'lineageEdgeId' is None")
+        self.assertEqual(lineage_edge_version.lineageEdgeId, 0, "lineage_edge_version attribute 'lineageEdgeId', "
+                                                                "Expected: 0, Actual: " + str(
+            lineage_edge_version.lineageEdgeId))
+        self.assertIsNotNone(lineage_edge_version.fromRichVersionId, "lineage_edge_version attribute "
+                                                                     "'fromRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.fromRichVersionId, 4,
+                         "lineage_edge_version attribute 'fromRichVersionId', "
+                         "Expected: 4, Actual: " + str(lineage_edge_version.fromRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.toRichVersionId, "lineage_edge_version attribute "
+                                                                   "'toRichVersionId' is None")
+        self.assertEqual(lineage_edge_version.toRichVersionId, 5, "lineage_edge_version attribute 'toRichVersionId', "
+                                                                  "Expected: 5, Actual: " + str(
+            lineage_edge_version.toRichVersionId))
+        self.assertIsNotNone(lineage_edge_version.reference, "lineage_edge_version attribute 'reference' is None")
+        self.assertEqual(lineage_edge_version.reference, "testReference", "lineage_edge_version attribute 'reference', "
+                                                                          "Expected: testReference, "
+                                                                          "Actual: " + str(
+            lineage_edge_version.reference))
+        self.assertIsNotNone(lineage_edge_version.referenceParameters, "lineage_edge_version attribute "
+                                                                       "'referenceParameters' is None")
+        self.assertEqual(lineage_edge_version.referenceParameters, "testReferenceParameters",
+                         "lineage_edge_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_edge_version.referenceParameters))
+        self.assertIsNotNone(lineage_edge_version.tags, "lineage_edge_version attribute 'tags' is None")
+        self.assertEqual(lineage_edge_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_edge_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_edge_version.tags))
+        self.assertIsNotNone(lineage_edge_version.structureVersionId,
+                             "lineage_edge_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_edge_version.structureVersionId, 1,
+                         "lineage_edge_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_edge_version.structureVersionId))
+        self.assertIsNotNone(lineage_edge_version.parentIds, "lineage_edge_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_edge_version.parentIds, [2, 3], "lineage_edge_version attribute 'parentIds', "
+                                                                 "Expected: [2, 3], "
+                                                                 "Actual: " + str(lineage_edge_version.parentIds))
+        lineage_edge_version_json = lineage_edge_version.to_json()
+        self.assertEqual(lineage_edge_version_json, '{"reference": "testReference", "tags": {"testKey": "testValue"}, '
+                                                    '"lineageEdgeVersionId": 1, '
+                                                    '"referenceParameters": "testReferenceParameters", '
+                                                    '"fromRichVersionId": 4, "class": "LineageEdgeVersion", '
+                                                    '"parentIds": [2, 3], "structureVersionId": 1, '
+                                                    '"toRichVersionId": 5, "lineageEdgeId": 0, '
+                                                    '"sourceKey": "testSourceKey"}')
+
+    def test_git_get_lineage_graph_version(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey', 'testName', {'testKey': 'testValue'})
+        lineageGraphVersionId = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                              "testReferenceParameters",
+                                                              {'testKey': 'testValue'}, 1, [2, 3])
+        lineage_graph_version = git.getLineageGraphVersion(lineageGraphVersionId)
+        self.assertIsNotNone(lineage_graph_version.sourceKey, "lineage_graph_version attribute 'sourceKey' is None")
+        self.assertEqual(lineage_graph_version.sourceKey, 'testSourceKey',
+                         "lineage_graph_version attribute 'sourceKey', "
+                         "Expected: testSourceKey, "
+                         "Actual: " + str(
+                             lineage_graph_version.sourceKey))
+        self.assertIsNotNone(lineage_graph_version.lineageGraphId, "lineage_graph_version attribute "
+                                                                   "'lineageGraphId' is None")
+        self.assertEqual(lineage_graph_version.lineageGraphId, 0, "lineage_graph_version attribute 'lineageGraphId', "
+                                                                  "Expected: 0, Actual: " + str(
+            lineage_graph_version.lineageGraphId))
+        self.assertIsNotNone(lineage_graph_version.lineageEdgeVersionIds, "lineage_graph_version attribute "
+                                                                          "'lineageEdgeVersionIds' is None")
+        self.assertEqual(lineage_graph_version.lineageEdgeVersionIds, [5, 4],
+                         "lineage_graph_version attribute 'lineageEdgeVersionIds', "
+                         "Expected: [5, 4], Actual: " + str(lineage_graph_version.lineageEdgeVersionIds))
+        self.assertIsNotNone(lineage_graph_version.reference, "lineage_graph_version attribute 'reference' is None")
+        self.assertEqual(lineage_graph_version.reference, "testReference",
+                         "lineage_graph_version attribute 'reference', "
+                         "Expected: testReference, "
+                         "Actual: " + str(
+                             lineage_graph_version.reference))
+        self.assertIsNotNone(lineage_graph_version.referenceParameters, "lineage_graph_version attribute "
+                                                                        "'referenceParameters' is None")
+        self.assertEqual(lineage_graph_version.referenceParameters, "testReferenceParameters",
+                         "lineage_graph_version "
+                         "attribute "
+                         "'referenceParameters', "
+                         "Expected: testReferenceParameters, "
+                         "Actual: " + str(lineage_graph_version.referenceParameters))
+        self.assertIsNotNone(lineage_graph_version.tags, "lineage_graph_version attribute 'tags' is None")
+        self.assertEqual(lineage_graph_version.tags,
+                         {'testKey': 'testValue'},
+                         "lineage_graph_version attribute 'tags', "
+                         "Expected: " + str({'testKey': 'testValue'}) + ", Actual: " + str(lineage_graph_version.tags))
+        self.assertIsNotNone(lineage_graph_version.structureVersionId,
+                             "lineage_graph_version attribute 'structureVersionId' is None")
+        self.assertEqual(lineage_graph_version.structureVersionId, 1,
+                         "lineage_graph_version attribute 'structureVersionId', "
+                         "Expected: 1, "
+                         "Actual: " + str(lineage_graph_version.structureVersionId))
+        self.assertIsNotNone(lineage_graph_version.parentIds, "lineage_graph_version attribute 'parentIds' is None")
+        self.assertEqual(lineage_graph_version.parentIds, [2, 3], "lineage_graph_version attribute 'parentIds', "
+                                                                  "Expected: [2, 3], "
+                                                                  "Actual: " + str(lineage_graph_version.parentIds))
+        lineage_graph_version_json = lineage_graph_version.to_json()
+        self.assertEqual(lineage_graph_version_json, '{"lineageGraphId": 0, "lineageGraphVersionId": 1, '
+                                                     '"parentIds": [2, 3], "reference": "testReference", '
+                                                     '"tags": {"testKey": "testValue"}, '
+                                                     '"referenceParameters": "testReferenceParameters", '
+                                                     '"lineageEdgeVersionIds": [5, 4], '
+                                                     '"structureVersionId": 1, "sourceKey": "testSourceKey", '
+                                                     '"class": "LineageGraphVersion"}')
+
+    def test_git_get_node_latest_version(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey')
+        nodeVersionIdOne = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyOne': 'testValueOne'}, 1)
+        nodeVersionIdTwo = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyTwo': 'testValueTwo'}, 1, [nodeVersionIdOne])
+        nodeVersionIdThree = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                   {'testKeyThree': 'testValueThree'}, 1,
+                                                   [nodeVersionIdOne, nodeVersionIdTwo])
+        nodeVersionIdFour = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFour': 'testValueFour'}, 1, [nodeVersionIdTwo])
+        nodeVersionIdFive = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFive': 'testValueFive'}, 1, [nodeVersionIdThree])
+        nodeVersionIdSix = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeySix': 'testValueSix'}, 1,
+                                                 [nodeVersionIdTwo, nodeVersionIdThree])
+        nodeLastestIds = [nv.nodeVersionId for nv in git.getNodeLatestVersions('testSourceKey')]
+        self.assertNotIn(0, nodeLastestIds)
+        self.assertNotIn(1, nodeLastestIds)
+        self.assertNotIn(2, nodeLastestIds)
+        self.assertNotIn(3, nodeLastestIds)
+        self.assertIn(4, nodeLastestIds)
+        self.assertIn(5, nodeLastestIds)
+        self.assertIn(6, nodeLastestIds)
+
+    def test_git_get_edge_latest_version(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 10)
+        edgeVersionIdOne = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1)
+        edgeVersionIdTwo = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1, [edgeVersionIdOne])
+        edgeVersionIdThree = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1, [edgeVersionIdOne, edgeVersionIdTwo])
+        edgeVersionIdFour = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                  {'testKey': 'testValue'}, 1, [edgeVersionIdTwo])
+        edgeVersionIdFive = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                  {'testKey': 'testValue'}, 1, [edgeVersionIdThree])
+        edgeVersionIdSix = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1, [edgeVersionIdTwo, edgeVersionIdThree])
+        edgeLastestIds = [nv.edgeVersionId for nv in git.getEdgeLatestVersions('testSourceKey')]
+        self.assertNotIn(0, edgeLastestIds)
+        self.assertNotIn(1, edgeLastestIds)
+        self.assertNotIn(2, edgeLastestIds)
+        self.assertNotIn(3, edgeLastestIds)
+        self.assertIn(4, edgeLastestIds)
+        self.assertIn(5, edgeLastestIds)
+        self.assertIn(6, edgeLastestIds)
+
+    def test_git_get_graph_latest_version(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey')
+        graphVersionIdOne = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1)
+        graphVersionIdTwo = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1, [graphVersionIdOne])
+        graphVersionIdThree = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                     {'testKey': 'testValue'}, 1,
+                                                     [graphVersionIdOne, graphVersionIdTwo])
+        graphVersionIdFour = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                    {'testKey': 'testValue'}, 1, [graphVersionIdTwo])
+        graphVersionIdFive = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                    {'testKey': 'testValue'}, 1, [graphVersionIdThree])
+        graphVersionIdSix = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1,
+                                                   [graphVersionIdTwo, graphVersionIdThree])
+        graphLastestIds = [nv.graphVersionId for nv in git.getGraphLatestVersions('testSourceKey')]
+        self.assertNotIn(0, graphLastestIds)
+        self.assertNotIn(1, graphLastestIds)
+        self.assertNotIn(2, graphLastestIds)
+        self.assertNotIn(3, graphLastestIds)
+        self.assertIn(4, graphLastestIds)
+        self.assertIn(5, graphLastestIds)
+        self.assertIn(6, graphLastestIds)
+
+    def test_git_get_structure_latest_version(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey')
+        structureVersionIdOne = git.createStructureVersion(structureId, {'testKey': 'testValue'})
+        structureVersionIdTwo = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                           [structureVersionIdOne])
+        structureVersionIdThree = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                             [structureVersionIdOne, structureVersionIdTwo])
+        structureVersionIdFour = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                            [structureVersionIdTwo])
+        structureVersionIdFive = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                            [structureVersionIdThree])
+        structureVersionIdSix = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                           [structureVersionIdTwo, structureVersionIdThree])
+        structureLastestIds = [nv.structureVersionId for nv in git.getStructureLatestVersions('testSourceKey')]
+        self.assertNotIn(0, structureLastestIds)
+        self.assertNotIn(1, structureLastestIds)
+        self.assertNotIn(2, structureLastestIds)
+        self.assertNotIn(3, structureLastestIds)
+        self.assertIn(4, structureLastestIds)
+        self.assertIn(5, structureLastestIds)
+        self.assertIn(6, structureLastestIds)
+
+    def test_git_get_lineage_edge_latest_version(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey')
+        lineageEdgeVersionIdOne = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1)
+        lineageEdgeVersionIdTwo = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdOne])
+        lineageEdgeVersionIdThree = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageEdgeVersionIdOne, lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFour = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFive = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdThree])
+        lineageEdgeVersionIdSix = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdTwo, lineageEdgeVersionIdThree])
+        lineageEdgeLastestIds = [nv.lineageEdgeVersionId for nv in git.getLineageEdgeLatestVersions('testSourceKey')]
+        self.assertNotIn(0, lineageEdgeLastestIds)
+        self.assertNotIn(1, lineageEdgeLastestIds)
+        self.assertNotIn(2, lineageEdgeLastestIds)
+        self.assertNotIn(3, lineageEdgeLastestIds)
+        self.assertIn(4, lineageEdgeLastestIds)
+        self.assertIn(5, lineageEdgeLastestIds)
+        self.assertIn(6, lineageEdgeLastestIds)
+
+    def test_git_get_lineage_graph_latest_version(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey')
+        lineageGraphVersionIdOne = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1)
+        lineageGraphVersionIdTwo = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageGraphVersionIdOne])
+        lineageGraphVersionIdThree = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                   "testReferenceParameters",
+                                                                   {'testKey': 'testValue'}, 1,
+                                                                   [lineageGraphVersionIdOne, lineageGraphVersionIdTwo])
+        lineageGraphVersionIdFour = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                  "testReferenceParameters",
+                                                                  {'testKey': 'testValue'}, 1,
+                                                                  [lineageGraphVersionIdTwo])
+        lineageGraphVersionIdFive = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                  "testReferenceParameters",
+                                                                  {'testKey': 'testValue'}, 1,
+                                                                  [lineageGraphVersionIdThree])
+        lineageGraphVersionIdSix = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageGraphVersionIdTwo, lineageGraphVersionIdThree])
+        lineageGraphLastestIds = [nv.lineageGraphVersionId for nv in git.getLineageGraphLatestVersions('testSourceKey')]
+        self.assertNotIn(0, lineageGraphLastestIds)
+        self.assertNotIn(1, lineageGraphLastestIds)
+        self.assertNotIn(2, lineageGraphLastestIds)
+        self.assertNotIn(3, lineageGraphLastestIds)
+        self.assertIn(4, lineageGraphLastestIds)
+        self.assertIn(5, lineageGraphLastestIds)
+        self.assertIn(6, lineageGraphLastestIds)
+
+    def test_git_get_node_history(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey')
+        nodeVersionIdOne = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyOne': 'testValueOne'}, 1)
+        nodeVersionIdTwo = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyTwo': 'testValueTwo'}, 1, [nodeVersionIdOne])
+        nodeVersionIdThree = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                   {'testKeyThree': 'testValueThree'}, 1,
+                                                   [nodeVersionIdOne, nodeVersionIdTwo])
+        nodeVersionIdFour = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFour': 'testValueFour'}, 1, [nodeVersionIdTwo])
+        nodeVersionIdFive = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFive': 'testValueFive'}, 1, [nodeVersionIdThree])
+        nodeVersionIdSix = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeySix': 'testValueSix'}, 1,
+                                                 [nodeVersionIdThree])
+        self.assertEqual(git.getNodeHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_edge_history(self):
+        git = ground.GitImplementation()
+        edgeId = git.createEdge('testSourceKey', 0, 10)
+        edgeVersionIdOne = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1)
+        edgeVersionIdTwo = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1, [edgeVersionIdOne])
+        edgeVersionIdThree = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1, [edgeVersionIdOne, edgeVersionIdTwo])
+        edgeVersionIdFour = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                  {'testKey': 'testValue'}, 1, [edgeVersionIdTwo])
+        edgeVersionIdFive = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                  {'testKey': 'testValue'}, 1, [edgeVersionIdThree])
+        edgeVersionIdSix = git.createEdgeVersion(edgeId, 4, 5, 6, 7, "testReference", "testReferenceParameters",
+                                                 {'testKey': 'testValue'}, 1, [edgeVersionIdThree])
+        self.assertEqual(git.getEdgeHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_graph_history(self):
+        git = ground.GitImplementation()
+        graphId = git.createGraph('testSourceKey')
+        graphVersionIdOne = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1)
+        graphVersionIdTwo = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1, [graphVersionIdOne])
+        graphVersionIdThree = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                     {'testKey': 'testValue'}, 1,
+                                                     [graphVersionIdOne, graphVersionIdTwo])
+        graphVersionIdFour = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                    {'testKey': 'testValue'}, 1, [graphVersionIdTwo])
+        graphVersionIdFive = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                    {'testKey': 'testValue'}, 1, [graphVersionIdThree])
+        graphVersionIdSix = git.createGraphVersion(graphId, [4, 5, 6], "testReference", "testReferenceParameters",
+                                                   {'testKey': 'testValue'}, 1,
+                                                   [graphVersionIdThree])
+        self.assertEqual(git.getGraphHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_structure_history(self):
+        git = ground.GitImplementation()
+        structureId = git.createStructure('testSourceKey')
+        structureVersionIdOne = git.createStructureVersion(structureId, {'testKey': 'testValue'})
+        structureVersionIdTwo = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                           [structureVersionIdOne])
+        structureVersionIdThree = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                             [structureVersionIdOne, structureVersionIdTwo])
+        structureVersionIdFour = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                            [structureVersionIdTwo])
+        structureVersionIdFive = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                            [structureVersionIdThree])
+        structureVersionIdSix = git.createStructureVersion(structureId, {'testKey': 'testValue'},
+                                                           [structureVersionIdThree])
+        self.assertEqual(git.getStructureHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_lineage_edge_history(self):
+        git = ground.GitImplementation()
+        lineageEdgeId = git.createLineageEdge('testSourceKey')
+        lineageEdgeVersionIdOne = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1)
+        lineageEdgeVersionIdTwo = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdOne])
+        lineageEdgeVersionIdThree = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageEdgeVersionIdOne, lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFour = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFive = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdThree])
+        lineageEdgeVersionIdSix = git.createLineageEdgeVersion(lineageEdgeId, 5, 4, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdThree])
+        self.assertEqual(git.getLineageEdgeHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_lineage_graph_history(self):
+        git = ground.GitImplementation()
+        lineageGraphId = git.createLineageGraph('testSourceKey')
+        lineageGraphVersionIdOne = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1)
+        lineageGraphVersionIdTwo = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageGraphVersionIdOne])
+        lineageGraphVersionIdThree = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                   "testReferenceParameters",
+                                                                   {'testKey': 'testValue'}, 1,
+                                                                   [lineageGraphVersionIdOne, lineageGraphVersionIdTwo])
+        lineageGraphVersionIdFour = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                  "testReferenceParameters",
+                                                                  {'testKey': 'testValue'}, 1,
+                                                                  [lineageGraphVersionIdTwo])
+        lineageGraphVersionIdFive = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                  "testReferenceParameters",
+                                                                  {'testKey': 'testValue'}, 1,
+                                                                  [lineageGraphVersionIdThree])
+        lineageGraphVersionIdSix = git.createLineageGraphVersion(lineageGraphId, [5, 4], "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageGraphVersionIdThree])
+        self.assertEqual(git.getLineageGraphHistory('testSourceKey'), {'0': 1, '1': 3, '3': 6, '2': 4})
+
+    def test_git_get_node_version_adjacent_history(self):
+        git = ground.GitImplementation()
+        nodeId = git.createNode('testSourceKey')
+        nodeVersionIdOne = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyOne': 'testValueOne'}, 1)
+        nodeVersionIdTwo = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeyTwo': 'testValueTwo'}, 1, [nodeVersionIdOne])
+        nodeVersionIdThree = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                   {'testKeyThree': 'testValueThree'}, 1,
+                                                   [nodeVersionIdOne, nodeVersionIdTwo])
+        nodeVersionIdFour = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFour': 'testValueFour'}, 1, [nodeVersionIdTwo])
+        nodeVersionIdFive = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                  {'testKeyFive': 'testValueFive'}, 1, [nodeVersionIdThree])
+        nodeVersionIdSix = git.createNodeVersion(nodeId, "testReference", "testReferenceParameters",
+                                                 {'testKeySix': 'testValueSix'}, 1,
+                                                 [nodeVersionIdThree])
+        lineageEdgeId = git.createLineageEdge('testSourceKey')
+        lineageEdgeVersionIdOne = git.createLineageEdgeVersion(lineageEdgeId, 5, 3, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1)
+        lineageEdgeVersionIdTwo = git.createLineageEdgeVersion(lineageEdgeId, 3, 2, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdOne])
+        lineageEdgeVersionIdThree = git.createLineageEdgeVersion(lineageEdgeId, 4, 1, "testReference",
+                                                                 "testReferenceParameters",
+                                                                 {'testKey': 'testValue'}, 1,
+                                                                 [lineageEdgeVersionIdOne, lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFour = git.createLineageEdgeVersion(lineageEdgeId, 5, 2, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdTwo])
+        lineageEdgeVersionIdFive = git.createLineageEdgeVersion(lineageEdgeId, 6, 4, "testReference",
+                                                                "testReferenceParameters",
+                                                                {'testKey': 'testValue'}, 1,
+                                                                [lineageEdgeVersionIdThree])
+        lineageEdgeVersionIdSix = git.createLineageEdgeVersion(lineageEdgeId, 6, 1, "testReference",
+                                                               "testReferenceParameters",
+                                                               {'testKey': 'testValue'}, 1,
+                                                               [lineageEdgeVersionIdThree])
+        adjIdsOne = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdOne)]
+        self.assertEqual(2, len(adjIdsOne))
+        self.assertIn(10, adjIdsOne)
+        self.assertIn(13, adjIdsOne)
+        adjIdsTwo = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdTwo)]
+        self.assertEqual(2, len(adjIdsTwo))
+        self.assertIn(9, adjIdsTwo)
+        self.assertIn(11, adjIdsTwo)
+        adjIdsThree = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdThree)]
+        self.assertEqual(2, len(adjIdsThree))
+        self.assertIn(8, adjIdsThree)
+        self.assertIn(9, adjIdsThree)
+        adjIdsFour = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdFour)]
+        self.assertEqual(2, len(adjIdsFour))
+        self.assertIn(10, adjIdsFour)
+        self.assertIn(12, adjIdsFour)
+        adjIdsFive = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdFive)]
+        self.assertEqual(2, len(adjIdsFive))
+        self.assertIn(8, adjIdsFive)
+        self.assertIn(11, adjIdsFive)
+        adjIdsSix = [adj.lineageEdgeVersionId for adj in git.getNodeVersionAdjacentLineage(nodeVersionIdSix)]
+        self.assertEqual(2, len(adjIdsSix))
+        self.assertIn(12, adjIdsSix)
+        self.assertIn(13, adjIdsSix)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added the ground.py file, originally from https://github.com/ucbrise/jarvis, now with all datatypes implemented and all the GitImplementation methods completed, as well as adding unimplemented methods for the GroundAPI abstract class, and making some minor fixes along the way. Also, the testing file test_ground.py was added, which can be run from the command line with python 2 as 'python test_ground.py'. It contains comprehensive testing for the datatypes and GitImplementation.